### PR TITLE
Feature/data files

### DIFF
--- a/src/FitSamples/src/FitSampleSet.cpp
+++ b/src/FitSamples/src/FitSampleSet.cpp
@@ -143,7 +143,7 @@ double FitSampleSet::evalLikelihood() const{
     for( int iBin = 1 ; iBin <= sample.getMcContainer().histogram->GetNbinsX() ; iBin++ ){
       sampleLlh += (*_likelihoodFunctionPtr_)(
         sample.getMcContainer().histogram->GetBinContent(iBin),
-        sample.getMcContainer().histogram->GetBinError(iBin),
+        std::pow(sample.getMcContainer().histogram->GetBinError(iBin), 2),
         sample.getDataContainer().histogram->GetBinContent(iBin));
     }
     llh += sampleLlh;

--- a/src/FitSamples/src/SampleElement.cpp
+++ b/src/FitSamples/src/SampleElement.cpp
@@ -122,7 +122,7 @@ void SampleElement::refillHistogram(int iThread_){
     for( auto* eventPtr : perBinEventPtrList.at(iBin)){
       binContentArray[iBin+1] += eventPtr->getEventWeight();
     }
-    histogram->GetSumw2()->GetArray()[iBin+1] = TMath::Sqrt(binContentArray[iBin+1]);
+    histogram->GetSumw2()->GetArray()[iBin+1] = binContentArray[iBin+1];
     iBin += nbThreads;
   }
 }


### PR DESCRIPTION
- Add OA2020 likelihood function
- Remove the square root when filling the bin error in a histogram since GetSumw2() corresponds to the square of the bin error, and a bin error is the square root of the bin content. So GetSumw2() array should be filled with just the bin content.
- Apply a square on what we get from GetBinError() when calling the likelihood functions since they expect the square of the MC error bin. 