### PR TITLE
Fix: Build with and without CacheManager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,7 @@ option(BATCH_MODE "Build to run in a batch queue (affects output)" OFF)
 
 set(VERBOSE TRUE)
 
-
 include(${CMAKE_SOURCE_DIR}/cmake/cmessage.cmake)
-
 
 # Check for the availability of CUDA
 if(WITH_CUDA)
@@ -33,9 +31,10 @@ if(WITH_CUDA)
         cmessage(STATUS "CUDA support enabled")
         enable_language(CUDA)
         if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-            # The default is taken from the CUDAARCHS environment variable.  If it
-            # isn't set, then set it to the earliest non-deprecated architecture
-            #    2022: architectures before 52 are deprecated.
+            # The default is taken from the CUDAARCHS environment
+            # variable.  If it isn't set, then set it to the earliest
+            # non-deprecated architecture.
+            #   2022: architectures before 52 are deprecated.
             if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.23)
                 # After cmake 3.23, this can be set to all or all-major
                 set(CMAKE_CUDA_ARCHITECTURES all)
@@ -44,16 +43,14 @@ if(WITH_CUDA)
             endif()
         endif()
         cmessage(STATUS "CUDA compilation architectures: \"${CMAKE_CUDA_ARCHITECTURES}\"")
-    else()
-        cmessage(FATAL_ERROR "CUDA support requested, but not supported by this environment")
     endif(CMAKE_CUDA_COMPILER)
 else()
     cmessage(STATUS "CUDA support disabled")
 endif(WITH_CUDA)
 
-#Changes default install path to be a subdirectory of the build dir.
-#Should set the installation dir at configure time with
-#-DCMAKE_INSTALL_PREFIX=/install/path
+# Changes default install path to be a subdirectory of the build dir.
+# Should set the installation dir at configure time with
+# -DCMAKE_INSTALL_PREFIX=/install/path
 if(NOT DEFINED CMAKE_INSTALL_PREFIX
     OR CMAKE_INSTALL_PREFIX STREQUAL ""
     OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
@@ -105,7 +102,7 @@ if(ROOT_FOUND)
     execute_process (COMMAND root-config --has-minuit2
       OUTPUT_VARIABLE ROOT_minuit2_FOUND
       OUTPUT_STRIP_TRAILING_WHITESPACE)
-  endif(NOT ROOT_minuit2_found)
+  endif(NOT ROOT_minuit2_FOUND)
 else(ROOT_FOUND)
    cmessage(STATUS "Including local GENERATE_ROOT_DICTIONARY implementation.")
    include(${CMAKE_SOURCE_DIR}/cmake/GenROOTDictionary.cmake)
@@ -171,9 +168,13 @@ if (WITH_CUDA)
   # uncomment to enable the slow validations (NEVER during productions
   # or normal running).  These are whole code validations and are
   # extremely slow.
-  # add_definitions( -DCACHE_MANAGER_SLOW_VALIDATION)
+  if (CACHE_MANAGER_SLOW_VALIDATION)
+    cmessage(STATUS "Using slow validation for debugging")
+    cmessage(WARNING "Using slow validation so runs will be very slow")
+    add_definitions( -DCACHE_MANAGER_SLOW_VALIDATION)
+  endif (CACHE_MANAGER_SLOW_VALIDATION)
 
-  cmessage(STATUS "Enable GPU support (compiled, but only used if CUDA enabled)")
+  cmessage(STATUS "Enable GPU support (compiled, but only used when CUDA enabled)")
 endif()
 
 ################################################################################
@@ -311,24 +312,12 @@ include_directories( ${CMAKE_BINARY_DIR}/generated/ )
 set( MODULES
         Utils
         anaevents
+        CacheManager
         FitParameters
         FitSamples
-        CacheManager
         ErrorPropagator
         Fitter
 )
-
-# Each module will add it's primary target to this and they will be
-# automatically added to the executables.
-set(MODULETargets "")
-
-cmessage (STATUS "Setting up include directories...")
-include_directories( ${CMAKE_SOURCE_DIR}/include )
-foreach(mod ${MODULES})
-    cmessage (STATUS "Including headers of module: ${mod}")
-    include_directories( ${CMAKE_SOURCE_DIR}/src/${mod}/include )
-endforeach()
-
 
 cmessage (STATUS "Configuring modules...")
 foreach(mod ${MODULES})
@@ -340,7 +329,7 @@ add_subdirectory( ${CMAKE_SOURCE_DIR}/src/Applications )
 
 configure_file(cmake/build_setup.sh.in
   "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.sh" @ONLY)
-install(FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.sh" DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/setup.sh"
+  DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 cmessage( STATUS "Tagged Version ${gundam_VERSION_STRING}" )

--- a/cmake/gundam-build.sh
+++ b/cmake/gundam-build.sh
@@ -11,7 +11,7 @@
 #     help  -- This message
 #
 
-# Check that the source root directory is defined.  
+# Check that the source root directory is defined.
 if [ ${#GUNDAM_ROOT} == 0 ]; then
     echo GUNDAM is not setup yet.
     echo You can also run cmake and make by hand...
@@ -51,6 +51,7 @@ fi
 
 ONLY_CMAKE="no"
 RUN_CLEAN="no"
+DEFINES="-DCMAKE_INSTALL_PREFIX=${GUNDAM_INSTALL}"
 while [ "x${1}" != "x" ]; do
     case ${1} in
         fo*) # force
@@ -63,7 +64,7 @@ while [ "x${1}" != "x" ]; do
 	        rm -rf CMakeFiles
             fi
             ;;
-        cm*) # cmake 
+        cm*) # cmake
             shift
             echo Only run CMAKE.  Do not compile.
             ONLY_CMAKE="yes"
@@ -85,6 +86,11 @@ while [ "x${1}" != "x" ]; do
             echo "   help  -- This message"
             exit 0
             ;;
+        -*) # Add definitions
+            echo Add $1
+            DEFINES="${DEFINES} ${1}"
+            shift
+            ;;
         *)
             shift
             break
@@ -93,10 +99,12 @@ while [ "x${1}" != "x" ]; do
 done
 
 if [ ! -f CMakeCache.txt ]; then
-    cmake -DCMAKE_INSTALL_PREFIX=${GUNDAM_INSTALL} ${GUNDAM_ROOT}
+    echo cmake ${DEFINES} ${GUNDAM_ROOT}
+    cmake ${DEFINES} ${GUNDAM_ROOT}
 fi
 
 if [ ${RUN_CLEAN} = "yes" ]; then
+    echo make clean
     make clean
     echo Source cleaned.
 fi
@@ -105,9 +113,10 @@ if [ ${ONLY_CMAKE} = "yes" ]; then
     exit 0
 fi
 
-make || exit 1
+echo make -j1
+make -j1 || exit 1
+echo make install
 make install || exit 1
 
 echo "build:       " ${BUILD_LOCATION}
 echo "installation:" ${GUNDAM_INSTALL}
-

--- a/src/Applications/CMakeLists.txt
+++ b/src/Applications/CMakeLists.txt
@@ -18,14 +18,9 @@ set( APPLICATION_LIST
         YamlSandbox
 )
 
-include_directories(./include)
-
 foreach( app ${APPLICATION_LIST} )
     cmessage( STATUS "Defining app: ${app}" )
     add_executable( ${app} src/${app}.cxx)
-    target_link_libraries(${app} ${ROOT_LIBRARIES} ${YAMLCPP_LIBRARY})
-    foreach(mod ${MODULETargets})
-        target_link_libraries(${app} ${mod})
-    endforeach()
+    target_link_libraries(${app}  GundamFitter)
     install( TARGETS ${app} DESTINATION bin )
 endforeach()

--- a/src/CacheManager/CMakeLists.txt
+++ b/src/CacheManager/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if( WITH_CUDA )
   set(SRCFILES
           src/CacheManager.cpp
@@ -41,7 +40,14 @@ if( WITH_CUDA )
     add_library(GundamCache SHARED ${SRCFILES})
   endif()
 
+  # Make sure the current directories are available for the later
+  # compilation.
+  target_include_directories( GundamCache PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
   target_link_libraries( GundamCache PUBLIC
+          GundamFitParameters
+          GundamFitSamples
           ${ROOT_LIBRARIES}
           )
 
@@ -50,7 +56,4 @@ if( WITH_CUDA )
 
   install(TARGETS GundamCache DESTINATION lib)
 
-  set(MODULETargets ${MODULETargets} GundamCache PARENT_SCOPE)
-
 endif()
-

--- a/src/CacheManager/include/CacheIndexedSums.h
+++ b/src/CacheManager/include/CacheIndexedSums.h
@@ -27,6 +27,9 @@ private:
     // The accumulated weights for each histogram bin.
     std::unique_ptr<hemi::Array<double>> fSums;
 
+    // Cache of whether the result values in memory are valid.
+    bool fSumsValid;
+
     /// The (approximate) amount of memory required on the GPU.
     std::size_t fTotalBytes{};
 
@@ -53,7 +56,14 @@ public:
 
     /// Get the sum for index i from host memory.  This might trigger a copy
     /// from the device if that is necessary.
-    double GetSum(int i) const;
+    double GetSum(int i);
+
+    /// The pointer to the array of sums on the host.
+    const double* GetSumsPointer();
+
+    /// A pointer to the validity flag.
+    bool* GetSumsValidPointer();
+
 };
 
 // An MIT Style License

--- a/src/CacheManager/include/CacheWeights.h
+++ b/src/CacheManager/include/CacheWeights.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
-#include "array"
+#include <array>
 
 namespace Cache {
     class Weights;

--- a/src/CacheManager/src/CacheIndexedSums.cpp
+++ b/src/CacheManager/src/CacheIndexedSums.cpp
@@ -68,12 +68,15 @@ void Cache::IndexedSums::SetEventIndex(int event, int bin) {
 double Cache::IndexedSums::GetSum(int i) {
     if (i < 0) throw;
     if (fSums->size() <= i) throw;
-    fSumsValid = true;
-    return fSums->hostPtr()[i];
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the sum is set to be valid.  The use of isfinite is to
+    // make sure that the optimizer doesn't reorder the statements.
+    double value = fSums->hostPtr()[i];
+    if (std::isfinite(value)) fSumsValid = true;
+    return value;
 }
 
 const double* Cache::IndexedSums::GetSumsPointer() {
-    fSumsValid = true;
     return fSums->hostPtr();
 }
 

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -148,7 +148,7 @@ bool Cache::Weights::Apply() {
     // synchronization doesn't slow things down in GUNDAM.  The suspicion is
     // that it's because the CPU almost immediately uses the results, and the
     // sync prevents a small amount of mutex locking.
-    hemi::deviceSynchronize();
+    // hemi::deviceSynchronize();
 
     // A simple way to force a copy from the device.
     // fResults->hostPtr();

--- a/src/CacheManager/src/CacheWeights.cpp
+++ b/src/CacheManager/src/CacheWeights.cpp
@@ -64,13 +64,21 @@ Cache::Weights::~Weights() {}
 double Cache::Weights::GetResult(int i) {
     if (i < 0) throw;
     if (GetResultCount() <= i) throw;
-    fResultsValid = true;
-    return fResults->hostPtr()[i];
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the result is set to be valid.  The use of isfinite is
+    // to make sure that the optimizer doesn't reorder the statements.
+    double value = fResults->hostPtr()[i];
+    if (std::isfinite(value)) fResultsValid = true;
+    return value;
 }
 
 double Cache::Weights::GetResultFast(int i) {
-    fResultsValid = true;
-    return fResults->readOnlyHostPtr()[i];
+    // This odd ordering is to make sure the thread-safe hostPtr update
+    // finishes before the result is set to be valid.  The use of isfinite is
+    // to make sure that the optimizer doesn't reorder the statements.
+    double value = fResults->hostPtr()[i];
+    if (std::isfinite(value)) fResultsValid = true;
+    return value;
 }
 
 void Cache::Weights::SetResult(int i, double v) {

--- a/src/CacheManager/src/WeightCompactSpline.cpp
+++ b/src/CacheManager/src/WeightCompactSpline.cpp
@@ -105,8 +105,8 @@ void Cache::Weight::CompactSpline::AddSpline(int resultIndex,
     int sIndex = ReserveSpline(resultIndex,parIndex,xMin,xMax,NP);
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::CompactSpline::AddSpline
-    sDial->setGPUCacheName(GetName());
-    sDial->setGPUCachePointer(GetCachePointer(sIndex));
+    sDial->setCacheManagerName(GetName());
+    sDial->setCacheManagerValuePointer(GetCachePointer(sIndex));
 #endif
     for (int i=0; i<NP; ++i) {
         const double x = xMin + i*(xMax-xMin)/(NP-1);
@@ -548,6 +548,7 @@ bool Cache::Weight::CompactSpline::Apply() {
         );
 
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
+    // This MUST be done for slow validation.
 #warning Using SLOW VALIDATION and copying spine values
     fSplineValue->hostPtr();
 #endif

--- a/src/CacheManager/src/WeightGeneralSpline.cpp
+++ b/src/CacheManager/src/WeightGeneralSpline.cpp
@@ -104,8 +104,8 @@ void Cache::Weight::GeneralSpline::AddSpline(int resultIndex,
     int sIndex = ReserveSpline(resultIndex,parIndex,xMin,xMax,NP);
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::GeneralSpline::AddSpline
-    sDial->setGPUCacheName(GetName());
-    sDial->setGPUCachePointer(GetCachePointer(sIndex));
+    sDial->setCacheManagerName(GetName());
+    sDial->setCacheManagerValuePointer(GetCachePointer(sIndex));
 #endif
     for (int i=0; i<NP; ++i) {
         double x;

--- a/src/CacheManager/src/WeightUniformSpline.cpp
+++ b/src/CacheManager/src/WeightUniformSpline.cpp
@@ -104,8 +104,8 @@ void Cache::Weight::UniformSpline::AddSpline(int resultIndex,
     int sIndex = ReserveSpline(resultIndex,parIndex,xMin,xMax,NP);
 #ifdef CACHE_MANAGER_SLOW_VALIDATION
 #warning Using SLOW VALIDATION in Cache::Weight::UniformSpline::AddSpline
-    sDial->setGPUCacheName(GetName());
-    sDial->setGPUCachePointer(GetCachePointer(sIndex));
+    sDial->setCacheManagerName(GetName());
+    sDial->setCacheManagerValuePointer(GetCachePointer(sIndex));
 #endif
     for (int i=0; i<NP; ++i) {
         double x = xMin + i*(xMax-xMin)/(NP-1);
@@ -450,7 +450,7 @@ namespace {
 #ifdef CACHE_DEBUG
             int dim = id1-id0-2;
             if (rIndex[i] < PRINT_STEP) {
-                std::cout << "Splines kernel " << i
+                LogInfo << "CACHE_DEBUG: Splines kernel " << i
                        << " iEvt " << rIndex[i]
                        << " iPar " << pIndex[i]
                        << " = " << params[pIndex[i]]
@@ -461,7 +461,7 @@ namespace {
                        << " d: " << dim
                        << std::endl;
                 for (int k = 0; k < dim/2; ++k) {
-                    std::cout << "        " << k
+                    LogInfo << "CACHE_DEBUG:     " << k
                            << " x: " << knots[id0] + k*s
                            << " y: " << knots[id0+2+2*k]
                            << " m: " << knots[id0+2+2*k+1]

--- a/src/ErrorPropagator/CMakeLists.txt
+++ b/src/ErrorPropagator/CMakeLists.txt
@@ -22,7 +22,8 @@ else()
   add_library(GundamErrorPropagator SHARED ${SRCFILES})
 endif()
 
-
+target_include_directories(GundamErrorPropagator PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if( WITH_CUDA )
   target_link_libraries( GundamErrorPropagator
@@ -48,4 +49,3 @@ install(TARGETS GundamErrorPropagator DESTINATION lib)
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
 
-set(MODULETargets ${MODULETargets} GundamErrorPropagator PARENT_SCOPE)

--- a/src/FitParameters/CMakeLists.txt
+++ b/src/FitParameters/CMakeLists.txt
@@ -22,6 +22,9 @@ else()
   add_library(GundamFitParameters SHARED ${SRCFILES})
 endif()
 
+target_include_directories(GundamFitParameters PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 # Dependencies
 target_link_libraries( GundamFitParameters PUBLIC
         anaevents
@@ -36,4 +39,3 @@ install(TARGETS GundamFitParameters DESTINATION lib)
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
 
-set(MODULETargets ${MODULETargets} GundamFitParameters PARENT_SCOPE)

--- a/src/FitParameters/include/Dial.h
+++ b/src/FitParameters/include/Dial.h
@@ -75,16 +75,6 @@ public:
   virtual void buildResponseSplineCache();
   virtual void fillResponseCache() = 0;
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
-  // Debugging.  This is only meaningful when the GPU is filling the spline
-  // value cache (only filled during validation).  It's a nullptr otherwise,
-  // or not included in the object.
-  std::string getGPUCacheName() const {return _GPUCacheName_;}
-  void setGPUCacheName(std::string s) {_GPUCacheName_ = s;}
-  double* getGPUCachePointer() const {return _GPUCachePointer_;}
-  void setGPUCachePointer(double* v) {_GPUCachePointer_=v;}
-#endif
-
 protected:
   const DialType::DialType _dialType_;
   // The DialSet that owns this dial.  The dial DOES NOT OWN THIS POINTER
@@ -111,11 +101,29 @@ protected:
   double _mirrorLowEdge_{std::nan("unset")};
   double _mirrorRange_{std::nan("unset")};
 
-#ifdef CACHE_MANAGER_SLOW_VALIDATION
+#ifdef GUNDAM_USING_CUDA
   // Debugging.  This is only meaningful when the GPU is filling the spline
   // value cache (only filled during validation).
-  std::string _GPUCacheName_{"unset"};
-  double* _GPUCachePointer_{nullptr};
+public:
+  void setCacheManagerName(std::string s) {_CacheManagerName_ = s;}
+  void setCacheManagerIndex(int i) {_CacheManagerIndex_ = i;}
+  void setCacheManagerValuePointer(double* v) {_CacheManagerValue_ = v;}
+  void setCacheManagerValidPointer(bool* v) {_CacheManagerValid_ = v;}
+  std::string getCacheManagerName() {return _CacheManagerName_;}
+  int  getCacheManagerIndex() {return _CacheManagerIndex_;}
+  const double* getCacheManagerValuePointer() {return _CacheManagerValue_;}
+  const bool* getCacheManagerValidPointer() {return _CacheManagerValid_;}
+  void (*getCacheManagerUpdatePointer())() {return _CacheManagerUpdate_;}
+private:
+  std::string _CacheManagerName_{"unset"};
+  // An "opaque" index into the cache that is used to simplify bookkeeping.
+  int _CacheManagerIndex_{-1};
+  // A pointer to the cached result.
+  double* _CacheManagerValue_{nullptr};
+  // A pointer to the cache validity flag.
+  bool* _CacheManagerValid_{nullptr};
+  // A pointer to a callback to force the cache to be updated.
+  void (*_CacheManagerUpdate_)(){nullptr};
 #endif
 
   // Output

--- a/src/FitParameters/include/DialSet.h
+++ b/src/FitParameters/include/DialSet.h
@@ -44,6 +44,7 @@ public:
   TFormula *getApplyConditionFormula() const;
   const std::string &getDialLeafName() const;
   const std::string &getDialSubType() const;
+  const std::string &getParameterName() const;
   size_t getCurrentDialOffset() const;
   DialType::DialType getGlobalDialType() const;
   const Dial &getTemplateDial() const;

--- a/src/FitParameters/src/DialSet.cpp
+++ b/src/FitParameters/src/DialSet.cpp
@@ -94,6 +94,9 @@ void DialSet::initialize() {
 bool DialSet::isEnabled() const {
   return _isEnabled_;
 }
+const std::string& DialSet::getParameterName() const {
+  return _parameterName_;
+}
 const std::vector<std::string> &DialSet::getDataSetNameList() const {
   return _dataSetNameList_;
 }

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -4,7 +4,7 @@
 
 #include "TFile.h"
 
-#include <FitParameter.h>
+#include "FitParameter.h"
 #include "SplineDial.h"
 
 #include "Logger.h"

--- a/src/FitSamples/CMakeLists.txt
+++ b/src/FitSamples/CMakeLists.txt
@@ -13,6 +13,9 @@ else()
   add_library(GundamFitSamples SHARED ${SRCFILES})
 endif()
 
+target_include_directories(GundamFitSamples PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_link_libraries( GundamFitSamples PUBLIC
         GundamUtils
         GundamFitParameters
@@ -26,4 +29,3 @@ set_target_properties(
 
 install(TARGETS GundamFitSamples DESTINATION lib)
 
-set(MODULETargets ${MODULETargets} GundamFitSamples PARENT_SCOPE)

--- a/src/FitSamples/include/PhysicsEvent.h
+++ b/src/FitSamples/include/PhysicsEvent.h
@@ -53,15 +53,6 @@ public:
   const std::vector<GenericToolbox::LeafHolder> &getLeafContentList() const;
   const std::vector<std::string> *getCommonLeafNameListPtr() const;
 
-#ifdef GUNDAM_USING_CUDA
-  // Set the result index.
-  void setResultIndex(int i) {_GPUResultIndex_ = i;}
-  void setResultPointer(double* v) {_GPUResult_ = v;}
-  void setResultValidPointer(bool* v) {_GPUResultValid_ = v;}
-  int getResultIndex() {return _GPUResultIndex_;}
-  double* getResultPointer() {return _GPUResult_;}
-#endif
-
   // CORE
   // Filling up
   void hookToTree(TTree* tree_, bool throwIfLeafNotFound_ = true);
@@ -114,9 +105,21 @@ private:
   int _sampleBinIndex_{-1};
 
 #ifdef GUNDAM_USING_CUDA
-  int _GPUResultIndex_{-1};
-  double* _GPUResult_{nullptr};
-  bool* _GPUResultValid_{nullptr};
+public:
+  void setCacheManagerIndex(int i) {_CacheManagerIndex_ = i;}
+  int  getCacheManagerIndex() {return _CacheManagerIndex_;}
+  void setCacheManagerValuePointer(const double* v) {_CacheManagerValue_ = v;}
+  void setCacheManagerValidPointer(const bool* v) {_CacheManagerValid_ = v;}
+  void setCacheManagerUpdatePointer(void (*p)()) {_CacheManagerUpdate_ = p;}
+private:
+  // An "opaque" index into the cache that is used to simplify bookkeeping.
+  int _CacheManagerIndex_{-1};
+  // A pointer to the cached result.
+  const double* _CacheManagerValue_{nullptr};
+  // A pointer to the cache validity flag.
+  const bool* _CacheManagerValid_{nullptr};
+  // A pointer to a callback to force the cache to be updated.
+  void (*_CacheManagerUpdate_)(){nullptr};
 #endif
 
   // Caches

--- a/src/FitSamples/include/SampleElement.h
+++ b/src/FitSamples/include/SampleElement.h
@@ -38,7 +38,6 @@ public:
   std::vector<std::vector<PhysicsEvent*>> perBinEventPtrList;
   double histScale{1};
   bool isLocked{false};
-  int cacheManagerIndex{-1};
 
   // Methods
   void reserveEventMemory(size_t dataSetIndex_, size_t nEvents, const PhysicsEvent &eventBuffer_);
@@ -50,13 +49,28 @@ public:
 
   double getSumWeights() const;
 
-  int getCacheManagerIndex() const;
-  void setCacheManagerIndex(int i);
-  
   // debug
   void print() const;
 
   bool debugTrigger{false};
+
+#ifdef GUNDAM_USING_CUDA
+public:
+  void setCacheManagerIndex(int i) {_CacheManagerIndex_ = i;}
+  int  getCacheManagerIndex() {return _CacheManagerIndex_;}
+  void setCacheManagerValuePointer(const double* v) {_CacheManagerValue_ = v;}
+  void setCacheManagerValidPointer(const bool* v) {_CacheManagerValid_ = v;}
+  void setCacheManagerUpdatePointer(void (*p)()) {_CacheManagerUpdate_ = p;}
+private:
+  // An "opaque" index into the cache that is used to simplify bookkeeping.
+  int _CacheManagerIndex_{-1};
+  // A pointer to the cached result.
+  const double* _CacheManagerValue_{nullptr};
+  // A pointer to the cache validity flag.
+  const bool* _CacheManagerValid_{nullptr};
+  // A pointer to a callback to force the cache to be updated.
+  void (*_CacheManagerUpdate_)(){nullptr};
+#endif
 
 };
 

--- a/src/FitSamples/src/PhysicsEvent.cpp
+++ b/src/FitSamples/src/PhysicsEvent.cpp
@@ -5,8 +5,10 @@
 #include "PhysicsEvent.h"
 #include "SplineDial.h"
 
+#ifdef GUNDAM_USING_CUDA
 #include "CacheManager.h"
 #include "CacheWeights.h"
+#endif
 
 #include "Logger.h"
 

--- a/src/FitSamples/src/SampleElement.cpp
+++ b/src/FitSamples/src/SampleElement.cpp
@@ -117,12 +117,6 @@ void SampleElement::refillHistogram(int iThread_){
   // Faster that pointer shifter. -> would be slower if refillHistogram is
   // handled by the propagator
 
-  int histIndex = -1;
-#ifdef GUNDAM_USING_CUDA
-  Cache::Manager* cache = Cache::Manager::Get();
-  if (cache) histIndex = getCacheManagerIndex();
-#endif
-
   // Size = Nbins + 2 overflow (0 and last)
   auto* binContentArray = histogram->GetArray();
 
@@ -157,7 +151,6 @@ void SampleElement::refillHistogram(int iThread_){
                     << " " << delta
                     << std::endl;
         }
-#endif
 #endif
     }
     binContentArray[iBin+1] = content;

--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -15,6 +15,9 @@ else()
   add_library(GundamFitter SHARED ${SRCFILES})
 endif()
 
+target_include_directories(GundamFitter PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_link_libraries( GundamFitter PUBLIC
         GundamErrorPropagator
         ${ROOT_LIBRARIES}
@@ -29,4 +32,3 @@ install(TARGETS GundamFitter DESTINATION lib)
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
 
-set(MODULETargets ${MODULETargets} GundamFitter PARENT_SCOPE)

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -40,6 +40,11 @@ else()
   add_library(GundamUtils SHARED ${SRCFILES})
 endif()
 
+# Make sure the current directories are available for the later
+# compilation.
+target_include_directories( GundamUtils PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_link_libraries( GundamUtils PUBLIC
         ${ROOT_LIBRARIES}
         ${YAML_CPP_LIBRARIES}
@@ -52,4 +57,3 @@ install(TARGETS GundamUtils DESTINATION lib)
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
 
-set(MODULETargets ${MODULETargets} GundamUtils PARENT_SCOPE)

--- a/src/anaevents/CMakeLists.txt
+++ b/src/anaevents/CMakeLists.txt
@@ -12,6 +12,10 @@ else()
   add_library(anaevents SHARED ${SRCFILES})
 endif()
 
+# Make sure the current directories are available for the later
+# compilation.
+target_include_directories(anaevents PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 target_link_libraries( anaevents PUBLIC
   GundamUtils
   ${ROOT_LIBRARIES}
@@ -23,4 +27,3 @@ set_target_properties(
 
 install(TARGETS anaevents DESTINATION lib)
 
-set(MODULETargets ${MODULETargets} anaevents PARENT_SCOPE)

--- a/src/anaevents/include/AnaEvent.hh
+++ b/src/anaevents/include/AnaEvent.hh
@@ -16,8 +16,6 @@
 #include "Logger.h"
 #include "GenericToolbox.h"
 
-#include "FitParameterSet.h"
-#include "Dial.h"
 #include "DataBin.h"
 #include "DataBinSet.h"
 
@@ -31,6 +29,8 @@ namespace AnaEventType{
   )
 };
 
+class FitParameterSet;
+class Dial;
 
 class AnaEvent
 {


### PR DESCRIPTION
Fix problems that were pointed out when not using a CacheManager in the build.
  
* Simplify the CMakeList.txt files to directly reference the dependencies instead of listing everything as a dependency for everything (this allows cmake to identify dependency loops).
* Modify Cache::Manager so that it provides a PIMPL-like interface for cached values.  This removes the need for dependency loops between CacheManager, FitSample and FitParameters.
* Update gundam-build to make it easier to have cmake definitions.  This is a quality of life change, but makes building a little easier.

I've run tests with the expected cmake definition configurtions (with/without CacheManager, with/without GPU) but only on a single linux flavor (debian).