### PR TITLE
Fix: Dial refactor compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(COLOR_OUTPUT "Enable colored terminal output." ON)
 option(TTYCHECK "Enable check if output is being sent to terminal/TTY." ON)
 option(WITH_OPENMP "(OLD) Build with OpenMP libraries" OFF )
 option(WITH_CACHE_MANAGER "Build with precalculated weight cache" OFF)
+option(WITH_GENERIC_SPLINES "Do not solely depend on ROOT TSpline3" OFF)
 option(DISABLE_CUDA "Disable CUDA language check (enable for testing only)" OFF)
 option(YAMLCPP_DIR "Set custom path to yaml-cpp lib" OFF )
 option(ENABLE_DEV_MODE "Enable specific dev related printouts" OFF )
@@ -117,7 +118,6 @@ if(BATCH_MODE)
   add_definitions(-DGUNDAM_BATCH)
 endif(BATCH_MODE)
 
-
 ################################################################################
 #                            Check Dependencies
 ################################################################################
@@ -218,6 +218,13 @@ if (WITH_CACHE_MANAGER)
   cmessage(STATUS "Enable GPU support (compiled, but only used when CUDA enabled)")
 endif()
 
+if(NOT WITH_GENERIC_SPLINES)
+  if(WITH_CACHE_MANAGER)
+    cmessage(STATUS "Generic spline interface required with Cache::Manager")
+  else(WITH_CACHE_MANAGER)
+    add_definitions(-DUSE_TSPLINE3_EVAL)
+  endif(WITH_CACHE_MANAGER)
+endif(NOT WITH_GENERIC_SPLINES)
 
 ################################################################################
 #                       SubModules

--- a/src/CacheManager/src/CacheManager.cpp
+++ b/src/CacheManager/src/CacheManager.cpp
@@ -205,8 +205,8 @@ bool Cache::Manager::Build(FitSampleSet& sampleList) {
                 if (gDial) {
                     ++graphs;
                 }
-                const NormalizationDial* nDial
-                    = dynamic_cast<const NormalizationDial*>(dial);
+                const NormDial* nDial
+                    = dynamic_cast<const NormDial*>(dial);
                 if (nDial) {
                     ++norms;
                 }

--- a/src/FitParameters/include/SplineDial.h
+++ b/src/FitParameters/include/SplineDial.h
@@ -12,8 +12,6 @@
 #include "memory"
 #include "string"
 
-#define USE_TSPLINE3_EVAL
-
 class SplineDial : public Dial {
 
 public:
@@ -56,7 +54,8 @@ protected:
 #ifndef USE_TSPLINE3_EVAL
 public:
   typedef enum {
-    Undefined,  // Fall back to using plain old TSpline3
+    Undefined,  // This should not occur
+    ROOTSpline, // Use ROOTs cubic spline (i.e. TSpline3), cannot use with GPU
     Monotonic,  // Use a monotonic cubic spline (only uses function value)
     Uniform,    // Use a cubic spline with uniformly spaced knots
     General,    // A general cubic spline
@@ -67,11 +66,11 @@ public:
 
 protected:
   // The type of spline that should be used for this dial.
-  Subtype _splineType_;
+  Subtype _splineType_{ROOTSpline};
 
-  // A block of data to calculate the spline values.  This can be copied to
-  // the Cache::Manager and lets the same spline calculation be used here and
-  // there.
+  // A block of data to calculate the spline values.  This must be filled for
+  // the Cache::Manager to work, and provides the input for spline calculation
+  // functions that can be shared between the CPU and the GPU.
   std::vector<double> _splineData_;
 
   // This fills _splineData_ and sets the _splineType_.  It uses the spline

--- a/src/FitParameters/src/SplineDial.cpp
+++ b/src/FitParameters/src/SplineDial.cpp
@@ -79,8 +79,8 @@ const TSpline3* SplineDial::getSplinePtr() const {
 }
 
 double SplineDial::calcDial(double parameterValue_) {
-  if     (parameterValue_ <= _spline_.GetXmin()) { return _spline_.Eval(_spline_.GetXmin()); }
-  else if(parameterValue_ >= _spline_.GetXmax()) { return _spline_.Eval(_spline_.GetXmax()); }
+  if     (parameterValue_ <= _spline_.GetXmin()) { parameterValue_ = _spline_.GetXmin(); }
+  else if(parameterValue_ >= _spline_.GetXmax()) { parameterValue_ = _spline_.GetXmax(); }
 #ifdef USE_TSPLINE3_EVAL
   return _spline_.Eval(parameterValue_);
 #else
@@ -99,6 +99,9 @@ double SplineDial::calcDial(double parameterValue_) {
       dialResponse = CalculateMonotonicSpline(
           parameterValue_, -1E20, 1E20,
           _splineData_.data(), _splineData_.size());
+  }
+  else if (_splineType_ == SplineDial::ROOTSpline) {
+      dialResponse = _spline_.Eval(parameterValue_);
   }
   else {
       LogThrow("Must have a spline type defined");
@@ -163,6 +166,7 @@ const std::vector<double>& SplineDial::getSplineData() const {
 SplineDial::Subtype SplineDial::getSplineType() const {
   return _splineType_;
 }
+
 void SplineDial::fillSplineData() {
     // Check if the spline has uniformly spaced knots.  There is a flag for
     // this is TSpline3, but it's not uniformly (or ever) filled correctly.
@@ -192,6 +196,7 @@ void SplineDial::fillSplineData() {
     } while(false);
 
 }
+
 bool SplineDial::fillMonotonicSpline(bool uniformKnots) {
     // A monotonic spline has been explicitly requested
     if (!uniformKnots) {


### PR DESCRIPTION
This fixes a couple of missed changes in the dial refactor that kept Cache::Manager from compiling.  

- Fix: The name change from NormalizationDial -> NormDial was not fully propagated into Cache::Manager.  The two classes compatible.
- Fix: Cache::Manager requires the generic spline interface to provide the spline data.  This moves the compilation flag switching between the options into the top level CMakeLists.txt, and adds a warning/error when there is an incompatible compilation.  The default is the to use TSpline3
- Fix: Make sure parameter bounds are applied the same way for all splines

This touches CMakeLists.txt, SplineDial.h, and SplineDial.cpp (about 30 lines total)