### PR TITLE
Add timer for dial updates

### DIFF
--- a/src/DialDictionary/DialEngine/include/DialManager.h
+++ b/src/DialDictionary/DialEngine/include/DialManager.h
@@ -12,6 +12,7 @@
 
 #include <vector>
 
+#include "GenericToolbox.Time.h"
 
 class DialManager : public JsonBaseClass {
 
@@ -37,10 +38,12 @@ public:
   void invalidateInputBuffers();
   void updateDialState();
   void printSummaryTable() const;
+  auto& getUpdateTimer() const {return _updateTimer_;}
 
 private:
   ParametersManager* _parametersManagerPtr_{nullptr};
   std::vector<DialCollection> _dialCollectionList_;
+  GenericToolbox::Time::AveragedTimer<10> _updateTimer_;
 };
 
 

--- a/src/DialDictionary/DialEngine/src/DialManager.cpp
+++ b/src/DialDictionary/DialEngine/src/DialManager.cpp
@@ -68,6 +68,7 @@ void DialManager::clearEventByEventDials(){
   invalidateInputBuffers();
 }
 void DialManager::updateDialState(){
+  auto s{_updateTimer_.scopeTime()};
   for( auto& dialCollection : _dialCollectionList_ ) {
     dialCollection.updateInputBuffers();
     dialCollection.update();

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -191,6 +191,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
       t << "" << GenericToolbox::TablePrinter::NextColumn;
       t << "Propagator" << GenericToolbox::TablePrinter::NextColumn;
 
+      t << "Dial Update" << GenericToolbox::TablePrinter::NextColumn;
 #ifdef GUNDAM_USING_CACHE_MANAGER
       if( Cache::Manager::Get() != nullptr ){
         t << "Cache::Fill" << GenericToolbox::TablePrinter::NextColumn;
@@ -208,6 +209,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
       t << "Speed" << GenericToolbox::TablePrinter::NextColumn;
       t << _monitor_.iterationCounterClock.evalTickSpeed() << " it/s" << GenericToolbox::TablePrinter::NextColumn;
 
+      t << getModelPropagator().getDialManager().getUpdateTimer() << GenericToolbox::TablePrinter::NextColumn;
 
 #ifdef GUNDAM_USING_CACHE_MANAGER
       if( Cache::Manager::Get() != nullptr ){

--- a/src/Propagator/src/Propagator.cpp
+++ b/src/Propagator/src/Propagator.cpp
@@ -152,8 +152,6 @@ std::future<bool> Propagator::applyParameters(){
 }
 
 void Propagator::reweightEvents(bool updateDials) {
-  // timer start/stop in scope
-  auto s{reweightTimer.scopeTime()};
 
   if (updateDials) {
     // Make sure the dial state is updated before pulling the trigger on the
@@ -162,6 +160,9 @@ void Propagator::reweightEvents(bool updateDials) {
     if( _enableEigenToOrigInPropagate_ ){ _parManager_.convertEigenToOrig(); }
     _dialManager_.updateDialState();
   }
+
+  // timer start/stop after the dials are updated.
+  auto s{reweightTimer.scopeTime()};
 
   if( not _devSingleThreadReweight_ ){
     _threadPool_.runJob("Propagator::reweightEvents");


### PR DESCRIPTION
This times the dial update step separately from the reweighting and propagator interations per second.

Closes #847 