### PR TITLE
Solving memory issue with TClonesArray

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -12,6 +12,7 @@ option( ENABLE_DEV_MODE "Enable specific dev related printouts." OFF  )
 
 # extensions
 option( WITH_DOXYGEN "Build documentation with doxygen." OFF )
+option( WITH_ROOT_DICT_BUILD "Build the targets that require ROOT_GENERATE_DICTIONARY." ON )
 option( WITH_GUNDAM_ROOT_APP "Build app gundamRoot." ON )
 option( WITH_GUNDAM_SANDBOX_APP "Build app gundamRoot." OFF )
 option( WITH_CACHE_MANAGER "Enable compiling of the cache manager (required for GPU computing)." ON )

--- a/src/Applications/CMakeLists.txt
+++ b/src/Applications/CMakeLists.txt
@@ -23,7 +23,7 @@ if( WITH_GUNDAM_SANDBOX_APP )
     list(APPEND APPLICATION_LIST Sandbox)
 endif()
 
-if( WITH_GUNDAM_ROOT_APP )
+if( WITH_GUNDAM_ROOT_APP AND WITH_ROOT_DICT_BUILD )
     list(APPEND APPLICATION_LIST gundamRoot)
 
     # Need a full unfold of the source path
@@ -86,13 +86,13 @@ target_link_libraries( gundamConfigUnfolder GundamUtils )
 target_link_libraries( gundamConfigCompare GundamUtils )
 target_link_libraries( gundamPlotExtractor GundamUtils )
 
-if( WITH_GUNDAM_ROOT_APP )
+if( WITH_GUNDAM_ROOT_APP AND WITH_ROOT_DICT_BUILD )
 #target_sources( gundamRoot PRIVATE G__GundamRootDict.cxx )
 #target_link_libraries( gundamRoot GundamPropagator )
-target_link_libraries( gundamRoot
-    GundamRootDict GundamUtils
-    #    GundamPropagator
-    )
+    target_link_libraries( gundamRoot
+        GundamRootDict GundamUtils
+        #    GundamPropagator
+        )
 endif ()
 
 foreach( script ${SCRIPT_LIST} )

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -348,7 +348,6 @@ void DataDispenser::fetchRequestedLeaves(){
 
   if( _parameters_.useReweightEngine ){
     LogInfo << "Selecting dial collections..." << std::endl;
-    _cache_.dialCollectionsRefList.clear();
     for( auto& dialCollection : _cache_.propagatorPtr->getDialCollectionList() ){
       if( not dialCollection.isEnabled() ){ continue; }
       if( not dialCollection.isDatasetValid( _owner_->getName() ) ){ continue; }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -348,6 +348,7 @@ void DataDispenser::fetchRequestedLeaves(){
 
   if( _parameters_.useReweightEngine ){
     LogInfo << "Selecting dial collections..." << std::endl;
+    _cache_.dialCollectionsRefList.clear();
     for( auto& dialCollection : _cache_.propagatorPtr->getDialCollectionList() ){
       if( not dialCollection.isEnabled() ){ continue; }
       if( not dialCollection.isDatasetValid( _owner_->getName() ) ){ continue; }
@@ -1071,8 +1072,7 @@ void DataDispenser::loadEvent(int iThread_){
     }
   }
 
-  std::vector<DialBase*> eventByEventDialBuffer{};
-  eventByEventDialBuffer.resize(_cache_.dialCollectionsRefList.size(), nullptr);
+  std::unordered_map<size_t, DialBase*> eventByEventDialBuffer{};
 
   if(iThread_ == 0){
 
@@ -1250,8 +1250,6 @@ void DataDispenser::loadEvent(int iThread_){
 
       // only load event-by-event dials, binned dials etc. will be processed later
       for( auto *dialCollectionRef: _cache_.dialCollectionsRefList ){
-
-        eventByEventDialBuffer[dialCollectionRef->getIndex()] = nullptr;
 
         // if not event-by-event dial -> leave
         if( dialCollectionRef->getDialLeafName().empty() ){ continue; }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1188,6 +1188,9 @@ void DataDispenser::loadEvent(int iThread_){
 
   while( true ){
 
+    // VERY IMPORTANT
+    eventByEventDialBuffer.clear();
+
     {
       // make sure we request a new entry and wait once we go for another loop
       GenericToolbox::ScopedGuard readerGuard{
@@ -1397,8 +1400,6 @@ void DataDispenser::loadEvent(int iThread_){
 
     } // dial collection loop
 
-    // VERY IMPORTANT
-    eventByEventDialBuffer.clear();
   } // while ok
 
 }

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1073,6 +1073,7 @@ void DataDispenser::loadEvent(int iThread_){
   }
 
   std::unordered_map<int, DialBase*> eventByEventDialBuffer{};
+  eventByEventDialBuffer.reserve(_cache_.dialCollectionsRefList.size());
 
   if(iThread_ == 0){
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1369,31 +1369,30 @@ void DataDispenser::loadEvent(int iThread_){
           dialEntryPtr->interfaceIndex = freeSlotDial;
           dialEntryPtr++;
         }
-        else{
+      }
+      else{
 
-          if( dialCollectionRef->getDialInterfaceList().size() == 1
-              and dialCollectionRef->getDialBinSet().getBinList().empty()){
-            // There isn't any binning, and there is only one dial.
-            // In this case we don't need to check if the dial is in
-            // a bin.
+        if( dialCollectionRef->getDialInterfaceList().size() == 1
+            and dialCollectionRef->getDialBinSet().getBinList().empty()){
+          // There isn't any binning, and there is only one dial.
+          // In this case we don't need to check if the dial is in
+          // a bin.
+          dialEntryPtr->collectionIndex = iCollection;
+          dialEntryPtr->interfaceIndex = 0;
+          dialEntryPtr++;
+        }
+        else{
+          // There are multiple dials, or there is a list of bins
+          // to apply the dial to.  Check if the event falls into
+          // a bin, and apply the correct binning.  Some events
+          // may not be in any bin.
+          auto dialBinIdx = eventIndexingBuffer.getVariables().findBinIndex(
+              dialCollectionRef->getDialBinSet().getBinList());
+          if( dialBinIdx != -1 ){
             dialEntryPtr->collectionIndex = iCollection;
-            dialEntryPtr->interfaceIndex = 0;
+            dialEntryPtr->interfaceIndex = dialBinIdx;
             dialEntryPtr++;
           }
-          else{
-            // There are multiple dials, or there is a list of bins
-            // to apply the dial to.  Check if the event falls into
-            // a bin, and apply the correct binning.  Some events
-            // may not be in any bin.
-            auto dialBinIdx = eventIndexingBuffer.getVariables().findBinIndex(
-                dialCollectionRef->getDialBinSet().getBinList());
-            if( dialBinIdx != -1 ){
-              dialEntryPtr->collectionIndex = iCollection;
-              dialEntryPtr->interfaceIndex = dialBinIdx;
-              dialEntryPtr++;
-            }
-          }
-
         }
       }
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1072,7 +1072,7 @@ void DataDispenser::loadEvent(int iThread_){
     }
   }
 
-  std::unordered_map<size_t, DialBase*> eventByEventDialBuffer{};
+  std::unordered_map<int, DialBase*> eventByEventDialBuffer{};
 
   if(iThread_ == 0){
 

--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -20,20 +20,24 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/include
 )
 
+if( WITH_ROOT_DICT_BUILD )
+  set(CMAKE_CXX_FLAGS_DICT "-Wno-nonportable-include-path")
+  ROOT_GENERATE_DICTIONARY(
+    SimpleMcmc_Dict
+    ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/include/SimpleMcmc.h
+    MODULE ${LIB_NAME}
+    LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/src/SimpleMcmc_LinkDef.h
+    OPTIONS "${CMAKE_CXX_FLAGS_DICT}"
+  )
+
+  set( DICT_SIMPLEMCMC SimpleMcmc_Dict )
+endif()
+
 target_link_libraries(
     ${LIB_NAME}
     PUBLIC
     GundamStatisticalInference
-    SimpleMcmc_Dict
-)
-
-set(CMAKE_CXX_FLAGS_DICT "-Wno-nonportable-include-path")
-ROOT_GENERATE_DICTIONARY(
-  SimpleMcmc_Dict
-  ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/include/SimpleMcmc.h
-  MODULE ${LIB_NAME}
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/src/SimpleMcmc_LinkDef.h
-  OPTIONS "${CMAKE_CXX_FLAGS_DICT}"
+    ${DICT_SIMPLEMCMC}
 )
 
 install(TARGETS ${LIB_NAME} DESTINATION lib)

--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -30,25 +30,29 @@ if( WITH_ROOT_DICT_BUILD )
     OPTIONS "${CMAKE_CXX_FLAGS_DICT}"
   )
 
-  set( DICT_SIMPLEMCMC SimpleMcmc_Dict )
+  target_link_libraries(
+      ${LIB_NAME}
+      PUBLIC
+      GundamStatisticalInference
+      ${DICT_SIMPLEMCMC}
+  )
+
+  # Install the ROOT pcm and rootmap files
+  install(
+      FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/libGundamFitter_rdict.pcm
+      ${CMAKE_CURRENT_BINARY_DIR}/libGundamFitter.rootmap
+      DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/lib
+      COMPONENT
+      libraries
+  )
+else()
+  target_link_libraries(
+      ${LIB_NAME}
+      PUBLIC
+      GundamStatisticalInference
+  )
 endif()
 
-target_link_libraries(
-    ${LIB_NAME}
-    PUBLIC
-    GundamStatisticalInference
-    ${DICT_SIMPLEMCMC}
-)
-
 install(TARGETS ${LIB_NAME} DESTINATION lib)
-
-# Install the ROOT pcm and rootmap files
-install(
-  FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/libGundamFitter_rdict.pcm
-  ${CMAKE_CURRENT_BINARY_DIR}/libGundamFitter.rootmap
-  DESTINATION
-  ${CMAKE_INSTALL_PREFIX}/lib
-  COMPONENT
-  libraries
-)

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -204,7 +204,7 @@ bool Parameter::isInDomain(double value_, bool verbose_) const {
 
   if( not _parameterLimits_.hasBound() ){ return true; }
 
-  if( _parameterLimits_.isBellowMin(value_) ){
+  if( _parameterLimits_.isBelowMin(value_) ){
     if (verbose_) {
       LogError << "Value is below minimum: " << value_ << std::endl;
       LogError << "Summary: " << getSummary() << std::endl;

--- a/tests/fast-tests/100CovarianceTree.C
+++ b/tests/fast-tests/100CovarianceTree.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/fast-tests/100NormalizationTree.C
+++ b/tests/fast-tests/100NormalizationTree.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckBicubic.C
+++ b/tests/regular-tests/100CheckBicubic.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckBilinear.C
+++ b/tests/regular-tests/100CheckBilinear.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckCompactSpline.C
+++ b/tests/regular-tests/100CheckCompactSpline.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckGeneralSpline.C
+++ b/tests/regular-tests/100CheckGeneralSpline.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckGraph.C
+++ b/tests/regular-tests/100CheckGraph.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckMakeMonotonicSpline.C
+++ b/tests/regular-tests/100CheckMakeMonotonicSpline.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckMonotonicSpline.C
+++ b/tests/regular-tests/100CheckMonotonicSpline.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100CheckUniformSpline.C
+++ b/tests/regular-tests/100CheckUniformSpline.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>

--- a/tests/regular-tests/100HorrifyingTree.C
+++ b/tests/regular-tests/100HorrifyingTree.C
@@ -1,6 +1,6 @@
 # !/bin/bash
 # Wrap a ROOT macro as a script.
-root <<EOF
+root -n <<EOF
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Some of the user have reported issues while loading TGraphs from `TClonesArray`.

The issue came from some non-contiguous indices of some event-by-event dials. This would depend on the inputs if the user mixed the dial definition with simple norm ones.