### PR TITLE
Fixing CI root cxx

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -52,8 +52,24 @@ foreach(cxxstd IN ITEMS 23 20 17 14 11)
 endforeach()
 
 if(!IS_ROOT_CXX_STANDARD_SET)
-  cmessage( ALERT "ROOT C++ standard not set, use ROOT minimum (C++20)")
-  set(CMAKE_CXX_STANDARD 20)
+  # !! This is an old routine that use to work in 2025 !!
+  # Explicitly set the compiler version so that it will match the
+  # compiler that was used to compile ROOT.  Recent ROOT documentation
+  # explicitly notes that the appliation needs to use the same C++
+  # standard as ROOT.
+  if ( ROOT_cxx14_FOUND )
+    cmessage(STATUS "ROOT compiled with C++14")
+    set(CMAKE_CXX_STANDARD 14)
+  elseif ( ROOT_cxx17_FOUND )
+    cmessage(STATUS "ROOT compiled with C++17")
+    set(CMAKE_CXX_STANDARD 17)
+  elseif ( ROOT_cxx20_FOUND )
+    cmessage(STATUS "ROOT compiled with C++20")
+    set(CMAKE_CXX_STANDARD 20)
+  else ( ROOT_cxx14_FOUND )
+    cmessage( ALERT "ROOT C++ standard not set, use ROOT minimum (C++14)")
+    set(CMAKE_CXX_STANDARD 14)
+  endif ( ROOT_cxx14_FOUND)
 endif()
 
 if(CXX_MARCH_FLAG)

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -39,23 +39,22 @@ endif()
 # CXX standard is required and must match the version ROOT was compiled with.
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
-# Explicitly set the compiler version so that it will match the
-# compiler that was used to compile ROOT.  Recent ROOT documentation
-# explicitly notes that the appliation needs to use the same C++
-# standard as ROOT.
-if ( ROOT_cxx14_FOUND )
-  cmessage(STATUS "ROOT compiled with C++14")
-  set(CMAKE_CXX_STANDARD 14)
-elseif ( ROOT_cxx17_FOUND )
-  cmessage(STATUS "ROOT compiled with C++17")
-  set(CMAKE_CXX_STANDARD 17)
-elseif ( ROOT_cxx20_FOUND )
-  cmessage(STATUS "ROOT compiled with C++20")
+set(IS_ROOT_CXX_STANDARD_SET OFF)
+get_target_property(root_features ROOT::Core INTERFACE_COMPILE_FEATURES)
+foreach(cxxstd IN ITEMS 23 20 17 14 11)
+  if("cxx_std_${cxxstd}" IN_LIST root_features)
+    cmessage(STATUS "ROOT compiled with C++${cxxstd}")
+    set(IS_ROOT_CXX_STANDARD_SET ON)
+    set(CMAKE_CXX_STANDARD ${cxxstd})
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    break()
+  endif()
+endforeach()
+
+if(!IS_ROOT_CXX_STANDARD_SET)
+  cmessage( ALERT "ROOT C++ standard not set, use ROOT minimum (C++20)")
   set(CMAKE_CXX_STANDARD 20)
-else ( ROOT_cxx14_FOUND )
-  cmessage( ALERT "ROOT C++ standard not set, use ROOT minimum (C++14)")
-  set(CMAKE_CXX_STANDARD 14)
-endif ( ROOT_cxx14_FOUND)
+endif()
 
 if(CXX_MARCH_FLAG)
 endif()


### PR DESCRIPTION
In the latest Docker version of ROOT, the command `root-config --has-cxx..` doesn't work anymore. This PR fixes the issuer by using `root_feature flag`.