### PR TITLE
Fixing counting sample bins in CalcXsec

### DIFF
--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -757,9 +757,10 @@ int main(int argc, char** argv){
   int iBinGlobal{-1};
   int iBranchSeparation{-1};
 
-  LogDebugIf(GundamGlobals::isDebug()) << "Begging of loop over crossSectionDataList" << std::endl;
+  LogDebugIf(GundamGlobals::isDebug()) << "Begging of loop over crossSectionDataList size = " << crossSectionDataList.size() << std::endl;
 
   for( auto& xsec : crossSectionDataList ){
+    DEBUG_VAR(xsec.samplePtr->getName());
 
     for( int iBin = 0 ; iBin < xsec.samplePtr->getHistogram().getNbBins() ; iBin++ ){
       iBinGlobal++;
@@ -809,6 +810,9 @@ int main(int argc, char** argv){
 
   }
 
+  LogDebugIf(GundamGlobals::isDebug()) << "End of loop over crossSectionDataList" << std::endl;
+
+  LogDebugIf(GundamGlobals::isDebug()) << "Writing cov" << std::endl;
   globalCovMatrixHist->GetXaxis()->SetLabelSize(0.02);
   globalCovMatrixHist->GetYaxis()->SetLabelSize(0.02);
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCovMatrixHist, "covarianceMatrix");
@@ -816,6 +820,7 @@ int main(int argc, char** argv){
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[1], "parsCovarianceMatrix");
 
+  LogDebugIf(GundamGlobals::isDebug()) << "Writing cor" << std::endl;
   globalCorMatrixHist->GetXaxis()->SetLabelSize(0.02);
   globalCorMatrixHist->GetYaxis()->SetLabelSize(0.02);
   globalCorMatrixHist->GetZaxis()->SetRangeUser(-1, 1);

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -815,8 +815,12 @@ int main(int argc, char** argv){
   LogDebugIf(GundamGlobals::isDebug()) << "Writing cov" << std::endl;
   globalCovMatrixHist->GetXaxis()->SetLabelSize(0.02);
   globalCovMatrixHist->GetYaxis()->SetLabelSize(0.02);
+  LogDebugIf(GundamGlobals::isDebug()) << "SetLabelSize done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCovMatrixHist, "covarianceMatrix");
+  LogDebugIf(GundamGlobals::isDebug()) << "writeInTFileWithObjTypeExt done" << std::endl;
   auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, iBranchSeparation);
+  LogExitIf(chopped.empty(), "Invalid chopp?? " << globalCovMatrixHist->GetNbinsX() << " - " << iBranchSeparation);
+  LogDebugIf(GundamGlobals::isDebug()) << "chopTH2D done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[1], "parsCovarianceMatrix");
 

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -818,7 +818,6 @@ int main(int argc, char** argv){
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[1], "parsCovarianceMatrix");
 
-  LogDebugIf(GundamGlobals::isDebug()) << "Writing cor" << std::endl;
   globalCorMatrixHist->GetXaxis()->SetLabelSize(0.02);
   globalCorMatrixHist->GetYaxis()->SetLabelSize(0.02);
   globalCorMatrixHist->GetZaxis()->SetRangeUser(-1, 1);

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -760,37 +760,24 @@ int main(int argc, char** argv){
 
   std::vector<TH1D> binValues{};
   binValues.reserve(propagator.getSampleSet().getSampleList().size() );
-  int iBinGlobal{-1};
+  int iBinSampleGlobal{-1};
 
   for( auto& xsec : crossSectionDataList ){
 
     for( int iBin = 0 ; iBin < xsec.samplePtr->getHistogram().getNbBins() ; iBin++ ){
-      iBinGlobal++;
+      iBinSampleGlobal++;
 
       std::string binTitle = xsec.samplePtr->getHistogram().getBinContextList()[iBin].bin.getSummary();
       double binVolume = xsec.samplePtr->getHistogram().getBinContextList()[iBin].bin.getVolume();
 
-      xsec.histogram.SetBinContent( 1+iBin, (*meanValuesVector)[iBinGlobal] );
-      xsec.histogram.SetBinError( 1+iBin, std::sqrt( (*globalCovMatrix)[iBinGlobal][iBinGlobal] ) );
+      xsec.histogram.SetBinContent( 1+iBin, (*meanValuesVector)[iBinSampleGlobal] );
+      xsec.histogram.SetBinError( 1+iBin, std::sqrt( (*globalCovMatrix)[iBinSampleGlobal][iBinSampleGlobal] ) );
       xsec.histogram.GetXaxis()->SetBinLabel( 1+iBin, binTitle.c_str() );
 
-      globalCovMatrixHist->GetXaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-      globalCorMatrixHist->GetXaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-      globalCovMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-      globalCorMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-    }
-
-    for( auto& parset : propagator.getParametersManager().getParameterSetsList() ) {
-      if(not parset.isEnabled()){ continue; }
-      for( auto& par : parset.getParameterList() ) {
-        if(not par.isEnabled()){continue;}
-        iBinGlobal++;
-        std::string binTitle{par.getFullTitle()};
-        globalCovMatrixHist->GetXaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-        globalCorMatrixHist->GetXaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-        globalCovMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-        globalCorMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
-      }
+      globalCovMatrixHist->GetXaxis()->SetBinLabel(1+iBinSampleGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
+      globalCorMatrixHist->GetXaxis()->SetBinLabel(1+iBinSampleGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
+      globalCovMatrixHist->GetYaxis()->SetBinLabel(1+iBinSampleGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
+      globalCorMatrixHist->GetYaxis()->SetBinLabel(1+iBinSampleGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
     }
 
     xsec.histogram.SetMarkerStyle(kFullDotLarge);
@@ -808,6 +795,20 @@ int main(int argc, char** argv){
         &xsec.histogram, GenericToolbox::generateCleanBranchName( xsec.samplePtr->getName() )
     );
 
+  }
+
+  int iBinParGlobal{-1};
+  for( auto& parset : propagator.getParametersManager().getParameterSetsList() ) {
+    if(not parset.isEnabled()){ continue; }
+    for( auto& par : parset.getParameterList() ) {
+      if(not par.isEnabled()){continue;}
+      iBinParGlobal++;
+      std::string binTitle{par.getFullTitle()};
+      globalCovMatrixHist->GetXaxis()->SetBinLabel(1+nBinsSamples+iBinParGlobal, binTitle.c_str());
+      globalCorMatrixHist->GetXaxis()->SetBinLabel(1+nBinsSamples+iBinParGlobal, binTitle.c_str());
+      globalCovMatrixHist->GetYaxis()->SetBinLabel(1+nBinsSamples+iBinParGlobal, binTitle.c_str());
+      globalCorMatrixHist->GetYaxis()->SetBinLabel(1+nBinsSamples+iBinParGlobal, binTitle.c_str());
+    }
   }
 
   globalCovMatrixHist->GetXaxis()->SetLabelSize(0.02);

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -768,7 +768,6 @@ int main(int argc, char** argv){
   LogDebugIf(GundamGlobals::isDebug()) << "Begging of loop over crossSectionDataList size = " << crossSectionDataList.size() << std::endl;
 
   for( auto& xsec : crossSectionDataList ){
-    DEBUG_VAR(xsec.samplePtr->getName());
 
     for( int iBin = 0 ; iBin < xsec.samplePtr->getHistogram().getNbBins() ; iBin++ ){
       iBinGlobal++;
@@ -826,7 +825,7 @@ int main(int argc, char** argv){
   LogDebugIf(GundamGlobals::isDebug()) << "SetLabelSize done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCovMatrixHist, "covarianceMatrix");
   LogDebugIf(GundamGlobals::isDebug()) << "writeInTFileWithObjTypeExt done" << std::endl;
-  auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, iBranchSeparation);
+  auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, nBinsSamples);
   LogExitIf(chopped.empty(), "Invalid chopp?? " << globalCovMatrixHist->GetNbinsX() << " - " << iBranchSeparation << ", nBinsSamples="<<nBinsSamples << ", nParsThrown=" << nParsThrown);
   LogDebugIf(GundamGlobals::isDebug()) << "chopTH2D done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -745,15 +745,19 @@ int main(int argc, char** argv){
   auto* meanValuesVector = GenericToolbox::generateMeanVectorOfTree(
       useBestFitAsCentralValue ? xsecAtBestFitTree : xsecThrowTree
   );
+  LogDebugIf(GundamGlobals::isDebug()) << "generateCovarianceMatrixOfTree" << std::endl;
   auto* globalCovMatrix = GenericToolbox::generateCovarianceMatrixOfTree( xsecThrowTree );
 
   auto* globalCovMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(globalCovMatrix);
   auto* globalCorMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(GenericToolbox::convertToCorrelationMatrix(globalCovMatrix));
 
+  LogDebugIf(GundamGlobals::isDebug()) << "Reserve binValues" << std::endl;
   std::vector<TH1D> binValues{};
   binValues.reserve(propagator.getSampleSet().getSampleList().size() );
   int iBinGlobal{-1};
   int iBranchSeparation{-1};
+
+  LogDebugIf(GundamGlobals::isDebug()) << "Begging of loop over crossSectionDataList" << std::endl;
 
   for( auto& xsec : crossSectionDataList ){
 

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -503,6 +503,7 @@ int main(int argc, char** argv){
     }
     xsecEntry.branchBinsData.lock();
 
+    LogDebugIf(GundamGlobals::isDebug()) << "Adding sample branch: " << GenericToolbox::generateCleanBranchName( sample.getName() ) << "/" << GenericToolbox::joinVectorString(leafNameList, ":") << std::endl;
     xsecThrowTree->Branch(
         GenericToolbox::generateCleanBranchName( sample.getName() ).c_str(),
         xsecEntry.branchBinsData.getRawDataArray().data(),
@@ -544,6 +545,7 @@ int main(int argc, char** argv){
       parDataList[&parset].writeRawData( par.getParameterValue() );
     }
 
+    LogDebugIf(GundamGlobals::isDebug()) << "Adding par branch: " << GenericToolbox::generateCleanBranchName( parset.getName() ) << "/" << GenericToolbox::joinVectorString(leafNameList, ":") << std::endl;
     xsecThrowTree->Branch(
         GenericToolbox::generateCleanBranchName( parset.getName() ).c_str(),
         parDataList[&parset].getRawDataArray().data(),

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -751,7 +751,6 @@ int main(int argc, char** argv){
   auto* meanValuesVector = GenericToolbox::generateMeanVectorOfTree(
       useBestFitAsCentralValue ? xsecAtBestFitTree : xsecThrowTree
   );
-  LogDebugIf(GundamGlobals::isDebug()) << "generateCovarianceMatrixOfTree" << std::endl;
   auto* globalCovMatrix = GenericToolbox::generateCovarianceMatrixOfTree( xsecThrowTree );
 
   LogInfo << "Throw covariance matrix is " << globalCovMatrix->GetNrows() << " x " << globalCovMatrix->GetNcols() << std::endl;
@@ -759,13 +758,9 @@ int main(int argc, char** argv){
   auto* globalCovMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(globalCovMatrix);
   auto* globalCorMatrixHist = GenericToolbox::convertTMatrixDtoTH2D(GenericToolbox::convertToCorrelationMatrix(globalCovMatrix));
 
-  LogDebugIf(GundamGlobals::isDebug()) << "Reserve binValues" << std::endl;
   std::vector<TH1D> binValues{};
   binValues.reserve(propagator.getSampleSet().getSampleList().size() );
   int iBinGlobal{-1};
-  int iBranchSeparation{-1};
-
-  LogDebugIf(GundamGlobals::isDebug()) << "Begging of loop over crossSectionDataList size = " << crossSectionDataList.size() << std::endl;
 
   for( auto& xsec : crossSectionDataList ){
 
@@ -784,8 +779,6 @@ int main(int argc, char** argv){
       globalCovMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
       globalCorMatrixHist->GetYaxis()->SetBinLabel(1+iBinGlobal, GenericToolbox::joinPath(xsec.samplePtr->getName(), binTitle).c_str());
     }
-
-    iBranchSeparation = iBinGlobal+1;
 
     for( auto& parset : propagator.getParametersManager().getParameterSetsList() ) {
       if(not parset.isEnabled()){ continue; }
@@ -817,17 +810,11 @@ int main(int argc, char** argv){
 
   }
 
-  LogDebugIf(GundamGlobals::isDebug()) << "End of loop over crossSectionDataList" << std::endl;
-
-  LogDebugIf(GundamGlobals::isDebug()) << "Writing cov" << std::endl;
   globalCovMatrixHist->GetXaxis()->SetLabelSize(0.02);
   globalCovMatrixHist->GetYaxis()->SetLabelSize(0.02);
-  LogDebugIf(GundamGlobals::isDebug()) << "SetLabelSize done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCovMatrixHist, "covarianceMatrix");
-  LogDebugIf(GundamGlobals::isDebug()) << "writeInTFileWithObjTypeExt done" << std::endl;
   auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, int(nBinsSamples));
-  LogExitIf(chopped.empty(), "Invalid chopp?? " << globalCovMatrixHist->GetNbinsX() << " - " << iBranchSeparation << ", nBinsSamples="<<nBinsSamples << ", nParsThrown=" << nParsThrown);
-  LogDebugIf(GundamGlobals::isDebug()) << "chopTH2D done" << std::endl;
+  LogExitIf(chopped.empty(), "Invalid chopp?? " << globalCovMatrixHist->GetNbinsX() << ", nBinsSamples="<<nBinsSamples << ", nParsThrown=" << nParsThrown);
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[1], "parsCovarianceMatrix");
 

--- a/src/Applications/src/gundamCalcXsec.cxx
+++ b/src/Applications/src/gundamCalcXsec.cxx
@@ -825,7 +825,7 @@ int main(int argc, char** argv){
   LogDebugIf(GundamGlobals::isDebug()) << "SetLabelSize done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCovMatrixHist, "covarianceMatrix");
   LogDebugIf(GundamGlobals::isDebug()) << "writeInTFileWithObjTypeExt done" << std::endl;
-  auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, nBinsSamples);
+  auto chopped = GenericToolbox::chopTH2D(globalCovMatrixHist, int(nBinsSamples));
   LogExitIf(chopped.empty(), "Invalid chopp?? " << globalCovMatrixHist->GetNbinsX() << " - " << iBranchSeparation << ", nBinsSamples="<<nBinsSamples << ", nParsThrown=" << nParsThrown);
   LogDebugIf(GundamGlobals::isDebug()) << "chopTH2D done" << std::endl;
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCovarianceMatrix");
@@ -836,7 +836,7 @@ int main(int argc, char** argv){
   globalCorMatrixHist->GetYaxis()->SetLabelSize(0.02);
   globalCorMatrixHist->GetZaxis()->SetRangeUser(-1, 1);
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), globalCorMatrixHist, "correlationMatrix");
-  chopped = GenericToolbox::chopTH2D(globalCorMatrixHist, iBranchSeparation);
+  chopped = GenericToolbox::chopTH2D(globalCorMatrixHist, int(nBinsSamples));
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[0], "binsCorrelationMatrix");
   GenericToolbox::writeInTFileWithObjTypeExt(GenericToolbox::mkdirTFile(calcXsecDir, "matrices"), chopped[1], "parsCorrelationMatrix");
 


### PR DESCRIPTION
When defining more than one xsec sample, the generation of the covariance matrix would generate a segfault. This fixes the issue addressed in: https://github.com/gundam-organization/gundam/issues/884