### PR TITLE
don't reweight asimov

### DIFF
--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -387,8 +387,6 @@ void LikelihoodInterface::loadDataPropagator(){
     // copy the events directly from the model
     LogInfo << "Copying events from the model..." << std::endl;
     _dataPropagator_.copyEventsFrom( _modelPropagator_ );
-    _dataPropagator_.getDialManager().shrinkDialContainers();
-    _dataPropagator_.buildDialCache();
 
     // move the model back to the prior
     if( _dataType_ == DataType::Toy ){
@@ -449,10 +447,9 @@ void LikelihoodInterface::loadDataPropagator(){
       throwToyParameters(_dataPropagator_);
     } // throw asimov?
 
+    LogInfo << "Propagating weights on data events..." << std::endl;
+    _dataPropagator_.reweightEvents();
   }
-
-  LogInfo << "Propagating weights on data events..." << std::endl;
-  _dataPropagator_.reweightEvents();
 
   LogInfo << "Filling up data sample bin caches..." << std::endl;
   _threadPool_.runJob([this](int iThread){


### PR DESCRIPTION
Addressing issue in https://github.com/gundam-organization/gundam/issues/888

The fix is simple: don't reweight the Asimov "data". Asimov data is a special loading case where MC events are copied in the data histograms. This means that new copied "data" events don't get the associated dial. The cached weight value of each event from the MC should be used, that's why Asimov data need to not trigger "reweight" (which have no dials, hence the weight returned was always 1). Data histograms should be filled with copied event with their associated weight that was computed with the MC propagator.

It use to work prior to 2.1.0 since there was a bug in the way reweight was treated. Before, copied data events were keeping the dial references from the MC, so the reweight call would return the right weight. This was an issue when an independent data was load since no data dials were associated to the events. This led to the other issue reported here: https://github.com/gundam-organization/gundam/issues/802