### PR TITLE
Fix SimpleMcmc Burning to Burnin spelling mistake

### DIFF
--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -110,7 +110,7 @@ void SimpleMcmc::configureImpl(){
 
   // Get the sequence for the burn-in.
   _burninSequence_
-    = R"cxx(for (int chain = 0; chain < gMCMC.Burning(); ++chain) {
+    = R"cxx(for (int chain = 0; chain < gMCMC.Burnin(); ++chain) {
       gMCMC.RunChain("Burn-in chain", chain);})cxx";
   _config_.fillValue(_burninSequence_,"burninSequence");
 


### PR DESCRIPTION
Closes #890.  This is for 2.1.1