### PR TITLE
Adding `--disable-limits` option to gundamFitter

### DIFF
--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -219,6 +219,7 @@ int main(int argc, char** argv){
         {"generateOneSigmaPlots", "OneSigma"},
         {"enablePca", "PCA"},
         {"skipHesse", "NoHesse"},
+        {"disableParLimits", "NoLimits"},
         {"kickMc", "KickMc"},
         {"lightOutputMode", "Light"},
         {"toyFit", "ToyFit"},

--- a/src/Applications/src/gundamFitter.cxx
+++ b/src/Applications/src/gundamFitter.cxx
@@ -55,6 +55,7 @@ int main(int argc, char** argv){
   clParser.addDummyOption("Fit options");
   clParser.addTriggerOption("asimov", {"-a", "--asimov"}, "Use MC dataset to fill the data histograms");
   clParser.addTriggerOption("skipHesse", {"--skip-hesse"}, "Don't perform postfit error evaluation");
+  clParser.addTriggerOption("disableParLimits", {"--disable-limits"}, "Don't use limits during the fit");
   clParser.addOption("toyFit", {"--toy"}, "Run a toy fit (optional arg to provide toy index)", 1, true);
   clParser.addOption("injectParameterConfig", {"--inject-parameters"}, "Inject parameters defined in the provided config file");
   clParser.addOption("injectToyParameters", {"--inject-toy-parameter"}, "Inject parameters defined in the provided config file");
@@ -280,6 +281,8 @@ int main(int argc, char** argv){
   FitterEngine fitter(GenericToolbox::mkdirTFile(app.getOutfilePtr(), "FitterEngine"));
 
   gundamFitterConfig.fillValue(fitter.getConfig(), "fitterEngineConfig");
+
+  fitter.setDisableParLimits( clParser.isOptionTriggered("disableParLimits") );
 
   LogInfo << std::endl;
   LogInfo << "──────────────────────────────────" << std::endl;

--- a/src/Fitter/Engine/include/FitterEngine.h
+++ b/src/Fitter/Engine/include/FitterEngine.h
@@ -67,6 +67,7 @@ public:
   void setThrowGain(double throwGain_){ _throwGain_ = throwGain_; }
   void setPcaThreshold(double pcaThreshold_){ _pcaThreshold_ = pcaThreshold_; }
   void setPcaMethod(PcaMethod pcaMethod_){ _pcaMethod_ = pcaMethod_; }
+  void setDisableParLimits(bool disableParLimits_){ _disableParLimits_ = disableParLimits_; }
 
   // const-getters
   [[nodiscard]] auto& getPreFitParState() const{ return _preFitParState_; }
@@ -102,6 +103,7 @@ private:
   bool _generateOneSigmaPlots_{false};
   bool _doAllParamVariations_{false};
   bool _scaleParStepWithChi2Response_{false};
+  bool _disableParLimits_{false};
   double _throwGain_{1.};
   double _parStepGain_{0.1};
   bool _savePostfitEventTrees_{false};

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -143,6 +143,9 @@ void FitterEngine::initializeImpl(){
   if( _disableParLimits_ ) {
     LogWarning << "Disabling parameter limits..." << std::endl;
     for( auto& parSet : getLikelihoodInterface().getModelPropagator().getParametersManager().getParameterSetsList() ){
+      parSet.setGlobalParRange({std::nan("unset"), std::nan("unset")});
+      parSet.setEigenParRange({std::nan("unset"), std::nan("unset")});
+
       for( auto& par: parSet.getParameterList() ) {
         par.setLimits( {std::nan("unset"), std::nan("unset")} );
       }

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -144,11 +144,11 @@ void FitterEngine::initializeImpl(){
     LogWarning << "Disabling parameter limits..." << std::endl;
     for( auto& parSet : getLikelihoodInterface().getModelPropagator().getParametersManager().getParameterSetsList() ){
       for( auto& par: parSet.getParameterList() ) {
-        par.setLimits( {-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()} );
+        par.setLimits( {std::nan("unset"), std::nan("unset")} );
       }
 
       for( auto& par : parSet.getEigenParameterList() ) {
-        par.setLimits( {-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()} );
+        par.setLimits( {std::nan("unset"), std::nan("unset")} );
       }
     }
   }

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -140,6 +140,19 @@ void FitterEngine::initializeImpl(){
     getLikelihoodInterface().getPlotGenerator().configure(ConfigReader());
   }
 
+  if( _disableParLimits_ ) {
+    LogWarning << "Disabling parameter limits..." << std::endl;
+    for( auto& parSet : getLikelihoodInterface().getModelPropagator().getParametersManager().getParameterSetsList() ){
+      for( auto& par: parSet.getParameterList() ) {
+        par.setLimits( {-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()} );
+      }
+
+      for( auto& par : parSet.getEigenParameterList() ) {
+        par.setLimits( {-std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()} );
+      }
+    }
+  }
+
   getLikelihoodInterface().initialize();
 
   _parameterScanner_.setLikelihoodInterfacePtr( &getLikelihoodInterface() );

--- a/src/ParametersManager/include/ParameterSet.h
+++ b/src/ParametersManager/include/ParameterSet.h
@@ -39,6 +39,8 @@ public:
 
   // setters
   void setEnableDebugPrintout(bool enableDebugPrintout_){ _enableDebugPrintout_ = enableDebugPrintout_; }
+  void setGlobalParRange(GenericToolbox::Range globalParRange_){ _globalParRange_ = globalParRange_; }
+  void setEigenParRange(GenericToolbox::Range eigenParRange_){ _eigenParRange_ = eigenParRange_; }
 
 
   /// Process the input covariance matrix to make sure that fixed, free, and


### PR DESCRIPTION
`--disable-limits` is a new command line option that allows to run a fit ignoring all parameter limits. This is a debug feature used to monitor the effect on applying parameter bounds on the best-fit.