### PR TITLE
[Feature] Adding `sampleWeightVar` config option to the sample definitions

### DIFF
--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1276,20 +1276,6 @@ void DataDispenser::loadEvent(int iThread_){
         continue;
       }
 
-      if( not eventSample.getSampleWeightVar().empty() ){
-        double sampleWeight = eventIndexingBuffer.getVariables().fetchVariable(eventSample.getSampleWeightVar()).getVarAsDouble();
-        if( sampleWeight == 0 ) {
-          // skip it
-          continue;
-        }
-        if( sampleWeight < 0 ) {
-          LogError << "Negative sampleWeight:" << sampleWeight << std::endl;
-          LogError << "sampleWeight buffer is: " << eventIndexingBuffer.getSummary() << std::endl;
-          LogExit("Negative sampleWeight");
-        }
-        eventIndexingBuffer.getWeights().base *= sampleWeight;
-      }
-
       // dial collections may come with a condition formula
       if( eventSample.getSampleWeightFormula() != nullptr ){
         double sampleWeight = LoaderUtils::evalFormula(eventIndexingBuffer, eventSample.getSampleWeightFormula().get());

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -49,7 +49,7 @@ void DataDispenser::prepareConfig(ConfigReader &config_){
     {"dialIndexFormula"},
     {"overridePropagatorConfig"},
     {"selectionCutFormula"},
-    {"nominalWeightFormula"},
+    {"nominalTreeWeightFormula", {"nominalWeightFormula"}},
     {"variableDict", {"overrideLeafDict"}},
     {"fromModel", {"fromMc"}},
     {"evalModelAt"},
@@ -130,7 +130,7 @@ void DataDispenser::configureImpl(){
   _config_.fillValue(_parameters_.evalModelAt, "evalModelAt");
 
   _config_.fillFormula(_parameters_.selectionCutFormulaStr, "selectionCutFormula", "&&");
-  _config_.fillFormula(_parameters_.nominalWeightFormulaStr, "nominalWeightFormula", "*");
+  _config_.fillFormula(_parameters_.nominalWeightFormulaStr, "nominalTreeWeightFormula", "*");
 
 }
 void DataDispenser::initializeImpl(){
@@ -1274,6 +1274,20 @@ void DataDispenser::loadEvent(int iThread_){
           }
         }
         continue;
+      }
+
+      if( not eventSample.getSampleWeightVar().empty() ){
+        double sampleWeight = eventIndexingBuffer.getVariables().fetchVariable(eventSample.getSampleWeightVar()).getVarAsDouble();
+        if( sampleWeight == 0 ) {
+          // skip it
+          continue;
+        }
+        if( sampleWeight < 0 ) {
+          LogError << "Negative sampleWeight:" << sampleWeight << std::endl;
+          LogError << "sampleWeight buffer is: " << eventIndexingBuffer.getSummary() << std::endl;
+          LogExit("Negative sampleWeight");
+        }
+        eventIndexingBuffer.getWeights().base *= sampleWeight;
       }
 
       // dialIndexTreeFormula is modified by the TChain reader

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1290,6 +1290,21 @@ void DataDispenser::loadEvent(int iThread_){
         eventIndexingBuffer.getWeights().base *= sampleWeight;
       }
 
+      // dial collections may come with a condition formula
+      if( eventSample.getSampleWeightFormula() != nullptr ){
+        double sampleWeight = LoaderUtils::evalFormula(eventIndexingBuffer, eventSample.getSampleWeightFormula().get());
+        if( sampleWeight == 0 ) {
+          // skip it
+          continue;
+        }
+        if( sampleWeight < 0 ) {
+          LogError << "Negative sampleWeight:" << sampleWeight << std::endl;
+          LogError << "sampleWeight buffer is: " << eventIndexingBuffer.getSummary() << std::endl;
+          LogExit("Negative sampleWeight");
+        }
+        eventIndexingBuffer.getWeights().base *= sampleWeight;
+      }
+
       // dialIndexTreeFormula is modified by the TChain reader
       int dialCloneArrayIndex{0};
       if( threadSharedData.buffer.dialIndex != nullptr ){

--- a/src/SamplesManager/include/Sample.h
+++ b/src/SamplesManager/include/Sample.h
@@ -48,6 +48,7 @@ public:
   [[nodiscard]] auto getIndex() const{ return _index_; }
   [[nodiscard]] auto& getName() const{ return _name_; }
   [[nodiscard]] auto& getSelectionCutsStr() const{ return _selectionCutStr_; }
+  [[nodiscard]] auto& getSampleWeightVar() const{ return _sampleWeightVar_; }
   [[nodiscard]] auto& getBinningFilePath() const{ return _binningConfig_; }
   [[nodiscard]] auto& getHistogram() const{ return _histogram_; }
   [[nodiscard]] auto& getEventList() const{ return _eventList_; }
@@ -81,6 +82,7 @@ private:
   int _index_{-1};
   std::string _name_;
   std::string _selectionCutStr_;
+  std::string _sampleWeightVar_;
   ConfigReader _binningConfig_;
   std::vector<std::string> _enabledDatasetList_;
 

--- a/src/SamplesManager/include/Sample.h
+++ b/src/SamplesManager/include/Sample.h
@@ -49,6 +49,8 @@ public:
   [[nodiscard]] auto& getName() const{ return _name_; }
   [[nodiscard]] auto& getSelectionCutsStr() const{ return _selectionCutStr_; }
   [[nodiscard]] auto& getSampleWeightVar() const{ return _sampleWeightVar_; }
+  [[nodiscard]] auto& getSampleWeightFormula() const{ return _sampleWeightFormula_; }
+  [[nodiscard]] auto& getSampleWeightFormulaStr() const{ return _sampleWeightFormulaStr_; }
   [[nodiscard]] auto& getBinningFilePath() const{ return _binningConfig_; }
   [[nodiscard]] auto& getHistogram() const{ return _histogram_; }
   [[nodiscard]] auto& getEventList() const{ return _eventList_; }
@@ -83,6 +85,7 @@ private:
   std::string _name_;
   std::string _selectionCutStr_;
   std::string _sampleWeightVar_;
+  std::string _sampleWeightFormulaStr_;
   ConfigReader _binningConfig_;
   std::vector<std::string> _enabledDatasetList_;
 
@@ -92,6 +95,7 @@ private:
   Histogram _histogram_{};
   std::vector<Event> _eventList_{};
   std::vector<DatasetProperties> _loadedDatasetList_{};
+  std::shared_ptr<TFormula> _sampleWeightFormula_{nullptr};
 
 };
 

--- a/src/SamplesManager/include/Sample.h
+++ b/src/SamplesManager/include/Sample.h
@@ -48,7 +48,6 @@ public:
   [[nodiscard]] auto getIndex() const{ return _index_; }
   [[nodiscard]] auto& getName() const{ return _name_; }
   [[nodiscard]] auto& getSelectionCutsStr() const{ return _selectionCutStr_; }
-  [[nodiscard]] auto& getSampleWeightVar() const{ return _sampleWeightVar_; }
   [[nodiscard]] auto& getSampleWeightFormula() const{ return _sampleWeightFormula_; }
   [[nodiscard]] auto& getSampleWeightFormulaStr() const{ return _sampleWeightFormulaStr_; }
   [[nodiscard]] auto& getBinningFilePath() const{ return _binningConfig_; }
@@ -84,7 +83,6 @@ private:
   int _index_{-1};
   std::string _name_;
   std::string _selectionCutStr_;
-  std::string _sampleWeightVar_;
   std::string _sampleWeightFormulaStr_;
   ConfigReader _binningConfig_;
   std::vector<std::string> _enabledDatasetList_;

--- a/src/SamplesManager/src/Sample.cpp
+++ b/src/SamplesManager/src/Sample.cpp
@@ -22,6 +22,7 @@ void Sample::prepareConfig(ConfigReader &config_){
     {"binning", {"binningFile", "binningFilePath"}},
     {"selectionCutStr", {"selectionCuts"}},
     {"sampleWeightVar"},
+    {"sampleWeightFormula"},
     {"datasets"},
     // for xsec
     {"parSetBinning", {"parameterSetName"}},
@@ -39,6 +40,7 @@ void Sample::configureImpl(){
   _config_.fillValue(_binningConfig_, "binning");
   _config_.fillValue(_selectionCutStr_, "selectionCutStr");
   _config_.fillValue(_sampleWeightVar_, "sampleWeightVar");
+  _config_.fillValue(_sampleWeightFormulaStr_, "sampleWeightFormula");
   _config_.fillValue(_enabledDatasetList_, "datasets");
 
   LogThrowIf(_name_.empty(), "No name was provided for sample #" << _index_ << std::endl << _config_);
@@ -46,6 +48,15 @@ void Sample::configureImpl(){
   if( not _isEnabled_ ){
     LogDebugIf(GundamGlobals::isDebug()) << "-> disabled" << std::endl;
     return;
+  }
+
+  if (not _sampleWeightFormulaStr_.empty()) {
+    _sampleWeightFormula_ = std::make_shared<TFormula>(
+      "_sampleWeightFormula_",
+      _sampleWeightFormulaStr_.c_str()
+    );
+    LogThrowIf(not _sampleWeightFormula_->IsValid(),
+               "\"" << _sampleWeightFormulaStr_ << "\": could not be parsed as formula expression.");
   }
 
   LogDebugIf(GundamGlobals::isDebug()) << "Reading binning: " << _binningConfig_ << std::endl;

--- a/src/SamplesManager/src/Sample.cpp
+++ b/src/SamplesManager/src/Sample.cpp
@@ -21,6 +21,7 @@ void Sample::prepareConfig(ConfigReader &config_){
     {"disableEventMcThrow"},
     {"binning", {"binningFile", "binningFilePath"}},
     {"selectionCutStr", {"selectionCuts"}},
+    {"sampleWeightVar"},
     {"datasets"},
     // for xsec
     {"parSetBinning", {"parameterSetName"}},
@@ -37,6 +38,7 @@ void Sample::configureImpl(){
   _config_.fillValue(_disableEventMcThrow_, "disableEventMcThrow");
   _config_.fillValue(_binningConfig_, "binning");
   _config_.fillValue(_selectionCutStr_, "selectionCutStr");
+  _config_.fillValue(_sampleWeightVar_, "sampleWeightVar");
   _config_.fillValue(_enabledDatasetList_, "datasets");
 
   LogThrowIf(_name_.empty(), "No name was provided for sample #" << _index_ << std::endl << _config_);

--- a/src/SamplesManager/src/Sample.cpp
+++ b/src/SamplesManager/src/Sample.cpp
@@ -21,7 +21,6 @@ void Sample::prepareConfig(ConfigReader &config_){
     {"disableEventMcThrow"},
     {"binning", {"binningFile", "binningFilePath"}},
     {"selectionCutStr", {"selectionCuts"}},
-    {"sampleWeightVar"},
     {"sampleWeightFormula"},
     {"datasets"},
     // for xsec
@@ -39,7 +38,6 @@ void Sample::configureImpl(){
   _config_.fillValue(_disableEventMcThrow_, "disableEventMcThrow");
   _config_.fillValue(_binningConfig_, "binning");
   _config_.fillValue(_selectionCutStr_, "selectionCutStr");
-  _config_.fillValue(_sampleWeightVar_, "sampleWeightVar");
   _config_.fillValue(_sampleWeightFormulaStr_, "sampleWeightFormula");
   _config_.fillValue(_enabledDatasetList_, "datasets");
 

--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -76,9 +76,6 @@ std::vector<std::string> SampleSet::fetchRequestedVariablesForIndexing() const{
     for (auto &binContext: sample.getHistogram().getBinContextList()) {
       for (auto &edges: binContext.bin.getEdgesList()) { GenericToolbox::addIfNotInVector(edges.varName, out); }
     }
-    if(not sample.getSampleWeightVar().empty()) {
-      GenericToolbox::addIfNotInVector(sample.getSampleWeightVar(), out);
-    }
     if( sample.getSampleWeightFormula() != nullptr ) {
       for( int iPar = 0 ; iPar < sample.getSampleWeightFormula()->GetNpar() ; iPar++ ){
         GenericToolbox::addIfNotInVector(sample.getSampleWeightFormula()->GetParName(iPar), out);

--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -79,6 +79,11 @@ std::vector<std::string> SampleSet::fetchRequestedVariablesForIndexing() const{
     if(not sample.getSampleWeightVar().empty()) {
       GenericToolbox::addIfNotInVector(sample.getSampleWeightVar(), out);
     }
+    if( sample.getSampleWeightFormula() != nullptr ) {
+      for( int iPar = 0 ; iPar < sample.getSampleWeightFormula()->GetNpar() ; iPar++ ){
+        GenericToolbox::addIfNotInVector(sample.getSampleWeightFormula()->GetParName(iPar), out);
+      }
+    }
   }
   return out;
 }

--- a/src/SamplesManager/src/SampleSet.cpp
+++ b/src/SamplesManager/src/SampleSet.cpp
@@ -76,6 +76,9 @@ std::vector<std::string> SampleSet::fetchRequestedVariablesForIndexing() const{
     for (auto &binContext: sample.getHistogram().getBinContextList()) {
       for (auto &edges: binContext.bin.getEdgesList()) { GenericToolbox::addIfNotInVector(edges.varName, out); }
     }
+    if(not sample.getSampleWeightVar().empty()) {
+      GenericToolbox::addIfNotInVector(sample.getSampleWeightVar(), out);
+    }
   }
   return out;
 }


### PR DESCRIPTION
This features adds the possibility to users to apply a specific weight for a given sample. This sample weight will be computed during the data loading from the ROOT files, and it will be applied on each event base weight.

```
name: "mySampleWithCustomWeight"
selectionCuts: "SelectedSample == 131"
sampleWeightVar: "myCustomWeight"
```