### PR TITLE
Fix Issue 904: Test not failing on bad script

### DIFF
--- a/tests/gundam-tests.sh
+++ b/tests/gundam-tests.sh
@@ -238,6 +238,8 @@ for d in ${TESTS}; do
             # The job exited with success, but look for a fail messsage
             if (tail -5 ${OUTPUT_DIR}/${LOG} | grep FAIL >> /dev/null); then
                 echo JOB FAILURE: ${i}
+            elif (tail -10 ${OUTPUT_DIR}/${LOG} | grep "Execution.*aborted" >> /dev/null); then
+                echo JOB FAILURE: ${i}
             else
                 echo JOB SUCCESS: ${i}
                 SUCCESS="yes"


### PR DESCRIPTION
The gundam-tests.sh script exited with success when root was passed a test script that would not compile.  This now fails if root can't compile the a cint script.

Closes #904