### PR TITLE
Fixing MCMC configs for tests

### DIFF
--- a/tests/regular-tests/200HorrifyingCov-config.yaml
+++ b/tests/regular-tests/200HorrifyingCov-config.yaml
@@ -14,9 +14,9 @@ scanParameters: false        # can be triggered with --scan
 generateOneSigmaPlots: false # can be enabled with --one-sigma
 
 fitterEngineConfig:
-  engineType: minimizer
 
-  mcmcConfig:
+  minimizerConfig:
+    type: SimpleMCMC
     algorithm: metropolis
     proposal: adaptive
     burninCycles: 3
@@ -31,13 +31,6 @@ fitterEngineConfig:
     adaptiveWindow: 5000
     adaptiveCovWindow: 5000
     adaptiveFreezeAfter: 1
-
-  minimizerConfig:
-    minimizer: "Minuit2"
-    algorithm: "Migrad"
-    errors: "Hesse"
-    print_level: 2
-    tolerance: 1E-6
 
   propagatorConfig:
     throwAsimovFitParameters: false

--- a/tests/regular-tests/200HorrifyingFit-config.yaml
+++ b/tests/regular-tests/200HorrifyingFit-config.yaml
@@ -12,9 +12,9 @@ scanParameters: false        # can be triggered with --scan
 generateOneSigmaPlots: false # can be enabled with --one-sigma
 
 fitterEngineConfig:
-  engineType: minimizer
 
   mcmcConfig:
+    type: SimpleMCMC
     algorithm: metropolis
     proposal: adaptive
     burninCycles: 3
@@ -30,12 +30,6 @@ fitterEngineConfig:
     adaptiveCovWindow: 5000
     adaptiveFreezeAfter: 1
 
-  minimizerConfig:
-    minimizer: "Minuit2"
-    algorithm: "Migrad"
-    errors: "Hesse"
-    print_level: 2
-    tolerance: 1E-6
 
   propagatorConfig:
     throwAsimovFitParameters: false


### PR DESCRIPTION
adding explicit `type` and removing `minimizerConfig` that makes a config collision with `mcmcConfig`. This prevented the associated tests to run properly.