### PR TITLE
Issue906/add googletest submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 	path = submodules/simple-cpp-cmd-line-parser
 	url = https://github.com/gundam-organization/simple-cpp-cmd-line-parser.git
 	branch = main
+[submodule "submodules/googletest"]
+	path = submodules/googletest
+	url = https://github.com/google/googletest.git

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -20,7 +20,7 @@ option( WITH_CUDA_LIB "Enable CUDA language check (Cache::Manager requires a GPU
 option( WITH_MINUIT2_MISSING "Allow MINUIT2 to be missing" OFF )
 option( WITH_PYTHON_INTERFACE "Compile the python interface modules" OFF )
 option( WITH_TESTS "Build CMake tests." ON )
-option( WITH_GOOGLE_TEST "Enables GoogleTest unit tests." OFF )
+option( WITH_GOOGLE_TEST "Enable GoogleTest (disable at your own risk).." ON )
 
 # compile helper
 option( YAMLCPP_DIR "Set custom path to yaml-cpp lib." OFF )

--- a/cmake/scripts/gundam-build.sh
+++ b/cmake/scripts/gundam-build.sh
@@ -9,7 +9,6 @@
 #     cmake -- Don't compile the source (only run cmake).
 #     clean -- Run clean the build area after running cmake (run make clean)
 #     keep-going  -- Continue after compilation errors (add -k to make)
-#     ctest -- Run tests directly with ctest
 #     test  -- Run tests after the build
 #     verbose -- Run make with verbose turned on.
 #     help  -- This message
@@ -59,7 +58,6 @@ if [ ! -d ${BUILD_LOCATION} ]; then
     echo Unable to access build location at ${BUILD_LOCATION}
     exit 1
 fi
-cd ${BUILD_LOCATION}
 
 # If GUNDAM_INSTALL is not set, then the installation is in the same
 # directory as the build.
@@ -67,6 +65,7 @@ if [ ${#GUNDAM_INSTALL} == 0 ]; then
     GUNDAM_INSTALL=${BUILD_LOCATION}
 fi
 
+FORCE_CMAKE="no"
 ONLY_CMAKE="no"
 RUN_CLEAN="no"
 RUN_TEST="no"
@@ -80,18 +79,13 @@ if [ "x${GUNDAM_JOBS}" == x ]; then
     echo XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     echo
 fi
-MAKE_OPTIONS=" -j${GUNDAM_JOBS} "
+MAKE_OPTIONS=""
 while [ "x${1}" != "x" ]; do
     case ${1} in
         fo*) # force
             shift
             echo Reconfigure build.
-            if [ -f  CMakeCache.txt ]; then
-	        rm CMakeCache.txt
-            fi
-            if [ -d CMakeFiles ]; then
-	        rm -rf CMakeFiles
-            fi
+            FORCE_CMAKE="yes"
             ;;
         cm*) # cmake
             shift
@@ -108,32 +102,26 @@ while [ "x${1}" != "x" ]; do
             echo Continue on errors
             MAKE_OPTIONS=" -k ${MAKE_OPTIONS}"
             ;;
-        ctest*) # test
-            shift
-            echo Run ctest
-            RUN_TEST="ctest"
-            ;;
-        test*) # test
+        test|ctest) # test
             shift
             echo Run tests
-            RUN_TEST="make-test"
+            RUN_TEST="yes"
             ;;
         ve*) # verbose
             shift
             export VERBOSE=true
             ;;
         he*) # help
-            echo 
+            echo
             echo "gundam-build [help|force|...] [-D<cmake-definitions>]"
             echo "   force -- Force cmake to ignore the cache"
             echo "   cmake -- Don't build the package (only run cmake)"
             echo "   clean -- Run make clean after cmake"
             echo "   keep  -- Keep going on a compilation error (make -k)"
-            echo "   ctest <ctest-arguments> -- Run ctest on the build"
-            echo "   test  -- Run tests after the build"
+            echo "   test <ctest-arguments> -- Run ctest on the build"
             echo "   verbose -- Run make with verbose turned on."
             echo "   help  -- This message"
-            echo 
+            echo
             exit 0
             ;;
         -D*) # Add definitions
@@ -147,39 +135,43 @@ while [ "x${1}" != "x" ]; do
     esac
 done
 
-if [ ${RUN_CLEAN} = "yes" ]; then
-    if [ ! -f Makefile ]; then
-        echo ERROR: Makefile does not exist -- cannot clean.
-        exit 1;
-    fi
-    echo make clean
-    make ${MAKE_OPTIONS} clean
-    echo Source cleaned.
-    exit 0
+if [ ! -f ${BUILD_LOCATION}/CMakeCache.txt -o ${FORCE_CMAKE} = "yes" ]; then
+    echo cmake -B ${BUILD_LOCATION} -S ${GUNDAM_ROOT} --fresh ${DEFINES}
+    cmake -B ${BUILD_LOCATION} -S ${GUNDAM_ROOT} --fresh ${DEFINES}
 fi
 
-if [ ! -f CMakeCache.txt ]; then
-    echo cmake ${DEFINES} ${GUNDAM_ROOT}
-    cmake ${DEFINES} ${GUNDAM_ROOT}
+if [ ${RUN_CLEAN} = "yes" ]; then
+    echo cmake --build ${BUILD_LOCATION} --target clean
+    cmake --build ${BUILD_LOCATION} --target clean
+    echo Source cleaned.
+    exit 0
 fi
 
 if [ ${ONLY_CMAKE} = "yes" ]; then
     exit 0
 fi
 
-echo make ${MAKE_OPTIONS}
-make ${MAKE_OPTIONS} || exit 1
-echo make install
-make ${MAKE_OPTIONS} install || exit 1
+echo cmake --build ${BUILD_LOCATION} \
+     --parallel ${GUNDAM_JOBS} \
+     -- ${MAKE_OPTIONS}
+cmake --build ${BUILD_LOCATION} \
+      --parallel ${GUNDAM_JOBS} \
+      -- ${MAKE_OPTIONS} \
+    || exit 1
 
-if [ ${RUN_TEST} = "ctest" ]; then
-    echo Run ctest $*
-    ctest $* || exit 1
-fi
+echo cmake --install ${BUILD_LOCATION} --parallel ${GUNDAM_JOBS} || exit 1
+cmake --install ${BUILD_LOCATION} --parallel ${GUNDAM_JOBS} || exit 1
 
-if [ ${RUN_TEST} = "make-test" ]; then
-    echo Run make test
-    make ${MAKE_OPTIONS} test || exit 1
+if [ ${RUN_TEST} = "yes" ]; then
+    echo ctest --test-dir ${BUILD_LOCATION} \
+          --parallel ${GUNDAM_JOBS} \
+          --output-on-failure \
+          $*
+    ctest --test-dir ${BUILD_LOCATION} \
+          --parallel ${GUNDAM_JOBS} \
+          --output-on-failure \
+          $* \
+        || exit 1
 fi
 
 echo "build:       " ${BUILD_LOCATION}

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -23,6 +23,7 @@ endfunction( checkSubmodule )
 checkSubmodule( cpp-generic-toolbox )
 checkSubmodule( simple-cpp-logger )
 checkSubmodule( simple-cpp-cmd-line-parser )
+checkSubmodule( googletest )
 
 ## Add the CmdLineParser
 # Reproduce needed parts of the simple-cpp-cmd-line-parser CMakeLists.txt
@@ -73,3 +74,6 @@ else()
   add_definitions( -D LOGGER_ENABLE_COLORS_ON_USER_HEADER=1 )
 endif()
 
+## GoogleTest as a subdirectory.  This makes it available to the
+# rest of the build using the "include(GoogleTest)" cmake module.
+add_subdirectory( ${CMAKE_SOURCE_DIR}/submodules/googletest )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,54 +29,48 @@ add_test(
 )
 
 if( WITH_GOOGLE_TEST )
-  ## Compiled unit tests using GoogleTest.  These are only run if GTest
-  ## is found.
-  find_package(GTest QUIET)
+  ## Compiled unit tests using GoogleTest.
+  include(GoogleTest)
 
-  if(GTEST_FOUND)
-    cmessage( STATUS "Compiling google tests" )
-    add_executable(gundamGTest_unitTest.exe
-      GTests/unitTest_JointProbability.cpp)
-    target_link_libraries(gundamGTest_unitTest.exe GTest::gtest_main)
-    target_link_libraries(gundamGTest_unitTest.exe GundamFitter)
-    gtest_discover_tests(gundamGTest_unitTest.exe)
+  cmessage( STATUS "Compiling google tests" )
+  add_executable(gundamGTest_unitTest.exe
+    GTests/unitTest_JointProbability.cpp)
+  target_link_libraries(gundamGTest_unitTest.exe GTest::gtest_main)
+  target_link_libraries(gundamGTest_unitTest.exe GundamFitter)
+  gtest_discover_tests(gundamGTest_unitTest.exe)
 
-    if( WITH_CACHE_MANAGER )
-      # Setup the hemi test suite for the host
+  if( WITH_CACHE_MANAGER )
+    # Setup the hemi test suite for the host
 
-      add_executable(gundamGTest_host.exe
-          GTests/hemiArrayTest.cpp
-          GTests/hemiExecutionPolicyTest.cpp
-          GTests/cachedSumsTest.cpp
-          GTests/hemiExternals.cpp)
-      target_link_libraries(gundamGTest_host.exe GTest::gtest_main)
-      target_link_libraries(gundamGTest_host.exe GundamCacheManager)
-      target_compile_definitions(gundamGTest_host.exe PUBLIC HEMI_CUDA_DISABLE)
-      gtest_discover_tests(gundamGTest_host.exe)
+    add_executable(gundamGTest_host.exe
+      GTests/hemiArrayTest.cpp
+      GTests/hemiExecutionPolicyTest.cpp
+      GTests/cachedSumsTest.cpp
+      GTests/hemiExternals.cpp)
+    target_link_libraries(gundamGTest_host.exe GTest::gtest_main)
+    target_link_libraries(gundamGTest_host.exe GundamCacheManager)
+    target_compile_definitions(gundamGTest_host.exe PUBLIC HEMI_CUDA_DISABLE)
+    gtest_discover_tests(gundamGTest_host.exe)
 
-      if(CMAKE_CUDA_COMPILER)
-        # Setup the hemi test suite for the device.
-        add_executable(gundamGTest_device.exe
-            GTests/hemiArrayTest.cu
-            GTests/hemiExecutionPolicyTest.cu
-            GTests/hemiLaunch.cu
-            GTests/cachedSumsTest.cu
-            GTests/hemiExternals.cpp)
-        target_link_libraries(gundamGTest_device.exe GTest::gtest_main)
-        target_link_libraries(gundamGTest_device.exe GundamCacheManager)
-        gtest_discover_tests(gundamGTest_device.exe)
-      endif(CMAKE_CUDA_COMPILER)
+    if(CMAKE_CUDA_COMPILER)
+      # Setup the hemi test suite for the device.
+      add_executable(gundamGTest_device.exe
+        GTests/hemiArrayTest.cu
+        GTests/hemiExecutionPolicyTest.cu
+        GTests/hemiLaunch.cu
+        GTests/cachedSumsTest.cu
+        GTests/hemiExternals.cpp)
+      target_link_libraries(gundamGTest_device.exe GTest::gtest_main)
+      target_link_libraries(gundamGTest_device.exe GundamCacheManager)
+      gtest_discover_tests(gundamGTest_device.exe)
+    endif(CMAKE_CUDA_COMPILER)
 
-    else( WITH_CACHE_MANAGER )
+  else( WITH_CACHE_MANAGER )
 
-      cmessage( WARNING "WITH_CACHE_MANAGER is set to false. Skipping Cache::Manager test executables." )
+    cmessage( WARNING "WITH_CACHE_MANAGER is set to false. Skipping Cache::Manager test executables." )
 
-    endif( WITH_CACHE_MANAGER )
-
-  else(GTEST_FOUND)
-    cmessage( WARNING "Google test is not available." )
-  endif(GTEST_FOUND)
+  endif( WITH_CACHE_MANAGER )
 
 else(WITH_GOOGLE_TEST)
-  cmessage( STATUS "Unit tests will not be used")
+  cmessage( WARNING "GoogleTests are not used and some unit tests are skipped")
 endif()


### PR DESCRIPTION
Remove the external dependency on googletest so that the unit tests will run on systems that do not have a native libgtest installation, and make sure that the default configuration builds the tests (changes the default, but it can be explicitly turned off during configuration using `-DWITH_GOOGLE_TEST=OFF`).  By default, failure to build the tests is a build failure, but the tests are not run unless explicitly requested (e.g. using `make test`, `ctest`, or `gundam-build test`).

The googletest library is currently setup as a git submodule pulling from the upstream repo (github.com/google/googletest.git), but we will probably want to either: 

1) fork into the gundam-organization so we choose how we follow upstream, 
2) or, actually copy the source code into our repo (the license allows that).  

This should be marked as a DRAFT until we chose the solution.

As part of testing the `googletest` installation, the `gundam-build.sh` script has a few cleanups to make sure that the `ctest` parallelism is working correctly.  The script is now building gundam "the cmake way", so it should also be a good example of how to build on a non-linux systems (but that script depends on bash, so it's probably linux dependent).

Closes #906