### PR TITLE
More compact unbinned event printout

### DIFF
--- a/src/DatasetManager/include/LoaderUtils.h
+++ b/src/DatasetManager/include/LoaderUtils.h
@@ -23,6 +23,7 @@ namespace LoaderUtils{
   void copyData(const Event& src_, Event& dst_);
   void copyData(Event& event_, const std::vector<const GenericToolbox::TreeBuffer::ExpressionBuffer*>& expList_);
   void fillBinIndex(Event& event_, const std::vector<Histogram::BinContext>& binList_);
+  std::vector<std::string> getRelevantVarNames(const std::vector<Histogram::BinContext>& binList_);
   double evalFormula(const Event& event_, const TFormula* formulaPtr_, std::vector<int>* indexDict_ = nullptr);
   void applyVarTransforms(Event& event_, const std::vector<EventVarTransformLib*>& transformList_);
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1271,10 +1271,20 @@ void DataDispenser::loadEvent(int iThread_){
         if( sampleBinIdxList.back() == -1 ){
           const int unbinnedEventThrottle = 5;
           if( this->_unbinnedEvents_++ < unbinnedEventThrottle ){
-            LogAlert <<  "Selected event not in a likelihood histogram bin: "
-                       << std::endl
-                       << eventIndexingBuffer.getSummary()
-                       << std::endl;
+
+            // grab relevant variables
+            auto varNames = LoaderUtils::getRelevantVarNames(eventSample.getHistogram().getBinContextList());
+
+            LogAlert <<  "Selected event not in a likelihood histogram bin: " << std::endl;
+            LogScopeIndent;
+            LogAlert << eventIndexingBuffer.getSummary(false) << std::endl;
+            LogAlert << "Variables used in binning{ ";
+            for( auto& varName : varNames ) {
+              LogAlert << varName << ": " << eventIndexingBuffer.getVariables().fetchVariable(varName).getVarAsDouble() << ", ";
+            }
+            LogAlert << "}" << std::endl;
+
+
             if ( this->_unbinnedEvents_.getValue() == unbinnedEventThrottle ) {
               LogAlert <<  "Further unbinned event warnings will be skipped."
                        << std::endl;

--- a/src/DatasetManager/src/LoaderUtils.cpp
+++ b/src/DatasetManager/src/LoaderUtils.cpp
@@ -38,6 +38,15 @@ namespace LoaderUtils{
     }
     event_.getIndices().bin = -1;
   }
+  std::vector<std::string> getRelevantVarNames(const std::vector<Histogram::BinContext>& binList_){
+    std::vector<std::string> relevantVarNames;
+    for( auto& bin : binList_ ){
+      for( auto& edges : bin.bin.getEdgesList() ) {
+        GenericToolbox::addIfNotInVector(edges.varName, relevantVarNames);
+      }
+    }
+    return relevantVarNames;
+  }
   double evalFormula(const Event& event_, const TFormula* formulaPtr_, std::vector<int>* indexDict_){
     LogThrowIf(formulaPtr_ == nullptr, GET_VAR_NAME_VALUE(formulaPtr_));
 

--- a/src/SamplesManager/include/Event.h
+++ b/src/SamplesManager/include/Event.h
@@ -34,7 +34,7 @@ public:
   // const core
   [[nodiscard]] size_t getSize() const;
   [[nodiscard]] double getEventWeight() const { return _weights_.current; }
-  [[nodiscard]] std::string getSummary() const;
+  [[nodiscard]] std::string getSummary(bool printVars_ = true) const;
   friend std::ostream& operator <<( std::ostream& o, const Event& this_ ){ o << this_.getSummary(); return o; }
 
 private:

--- a/src/SamplesManager/src/Event.cpp
+++ b/src/SamplesManager/src/Event.cpp
@@ -19,13 +19,15 @@ size_t Event::getSize() const{
 
   return staticSize + dynamicSize;
 }
-std::string Event::getSummary() const {
+std::string Event::getSummary(bool printVars_) const {
   std::stringstream ss;
   ss << "Indices{" << _indices_ << "}";
   ss << std::endl << "Weights{" << _weights_ << "}";
-  ss << std::endl << "Variables{";
-  if(not _variables_.empty()){ ss << std::endl << _variables_ << std::endl; }
-  ss << "}";
+  if(printVars_) {
+    ss << std::endl << "Variables{";
+    if(not _variables_.empty()){ ss << std::endl << _variables_ << std::endl; }
+    ss << "}";
+  }
   return ss.str();
 }
 


### PR DESCRIPTION
When some events are found to be unbinned, a printout warning is triggered showing the full event breakdown. For very refined configurations, this ends up into a storm of lines printouts showing all loaded variables in each unbinned event.

To improve clarity, this PR only printouts the relevant bin variables from the events.