### PR TITLE
LTS Issue 919: Fix calculate general spline

### DIFF
--- a/src/CacheManager/src/CacheParameters.cpp
+++ b/src/CacheManager/src/CacheParameters.cpp
@@ -67,7 +67,7 @@ bool Cache::Parameters::HasGPU(bool dump) {
                   << " Y:" << prop.maxGridSize[1]
                   << " Z:" << prop.maxGridSize[2] << std::endl;
         LogInfo << "CUDA WARP:                 " << prop.warpSize << std::endl;
-        LogInfo << "CUDA CLOCK:                " << prop.clockRate << std::endl;
+        // LogInfo << "CUDA CLOCK:                " << prop.clockRate << std::endl;
         LogInfo << "CUDA GLOBAL MEM:           " << prop.totalGlobalMem << std::endl;
         LogInfo << "CUDA SHARED MEM:           " << prop.sharedMemPerBlock << std::endl;
         LogInfo << "CUDA L2 CACHE MEM:         " << prop.l2CacheSize << std::endl;

--- a/src/Utils/include/CalculateGeneralSpline.h
+++ b/src/Utils/include/CalculateGeneralSpline.h
@@ -59,14 +59,15 @@ namespace {
         // Check to find a point that is less than x.  This is "brute force",
         // but since we know that the splines will usually have 7 or fewer
         // points, this may be faster, or comparable, to a binary search.
+        // This is benchmarked at 1.276 ms per call.
         const int knotCount = (dim-2)/3;
-// PROFILED aspen 2024/05/26 -- 7am (~195 it/sec)
-// LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
-// commit 5e9415e55b258d3d82d562942f03ac07c9937528
-//
-// ==1060642== Profiling result:
-//             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
-//  GPU activities:   38.10%  334.242s    261994  1.2758ms  1.2493ms  1.3344ms  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_003dc161_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
+        // PROFILED aspen 2024/05/26 -- 7am (~195 it/sec)
+        // LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
+        // commit 5e9415e55b258d3d82d562942f03ac07c9937528
+        //
+        // ==1060642== Profiling result:
+        //             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
+        //  GPU activities:   38.10%  334.242s    261994  1.2758ms  1.2493ms  1.3344ms  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_003dc161_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
         int ix = 0;
         if (x > data[2+3*(ix+1)+2] && ix < knotCount-2) ++ix; // 1
         if (x > data[2+3*(ix+1)+2] && ix < knotCount-2) ++ix; // 2
@@ -89,14 +90,15 @@ namespace {
         // but since we know that the splines will usually have 7 or fewer
         // points, this may be faster, or comparable, to a binary search.
         // This does the calculation without ifs (which can be slower for
-        // SIMD).
-// PROFILED aspen 2024/05/26 -- 7:30am (~180 it/sec)
-// LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
-// commit 5e9415e55b258d3d82d562942f03ac07c9937528
-//
-// ==1062228== Profiling result:
-//             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
-//  GPU activities:   38.08%  334.068s    262010  1.2750ms  1.2527ms  1.3348ms  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_001031e3_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
+        // SIMD). This is benchmarked at 1.275 ms per call.
+        //
+        // PROFILED aspen 2024/05/26 -- 7:30am (~180 it/sec)
+        // LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
+        // commit 5e9415e55b258d3d82d562942f03ac07c9937528
+        //
+        // ==1062228== Profiling result:
+        //             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
+        //  GPU activities:   38.08%  334.068s    262010  1.2750ms  1.2527ms  1.3348ms  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_001031e3_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
         const int knotCount = (dim-2)/3 - 2;
         int ix = 0;
         ix += (x > data[2+3*(ix+1)+2]) * (ix < knotCount); // 1
@@ -114,26 +116,47 @@ namespace {
         ix += (x > data[2+3*(ix+1)+2]) * (ix < knotCount); // 13
         ix += (x > data[2+3*(ix+1)+2]) * (ix < knotCount); // 14
         ix += (x > data[2+3*(ix+1)+2]) * (ix < knotCount); // 15
+#elif defined(CALCULATE_GENERAL_SPLINE_LOOPED_CHECK)
+        const int knotCount = (dim-2)/3 - 2;
+        int ix = 0;
+        // Define a non-branching conditional to update the offset.
+#define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount) && (x > data[2+3*(ix+ioff)+2])) ix += ioff
+        // __builtin_clz(knotCount) counts the number of leading zeros in
+        // knotCount (available in GCC/Clang).  31 - __builtin_clz(knotCount)
+        // calculates the position of the most significant bit.  1 << (31 -
+        // __builtin_clz(knotCount)) generates the largest power of 2 <=
+        // knotCount Not benchmarked, but adds extra branching loop to every
+        // iteration.  It assumes that knotCount is represented by a 32 bit
+        // integer.
+        for( int offset = 1 << ( 31 - __builtin_clz(knotCount) ) ; offset > 0 ; offset >>= 1 ){
+            CHECK_OFFSET(offset);
+        }
+#undef CHECK_OFFSET
 #else /* CALCULATE_GENERAL_SPLINE_BINARY_IF */
         // Check to find a point that is less than x.  This is a "brute force"
         // binary search, and the "if" has been checked and is efficient with
-        // CUDA.
-// PROFILED aspen 2024/05/26 -- 8:00am (~190 it/sec)
-// LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
-// commit 5e9415e55b258d3d82d562942f03ac07c9937528
-//
-// ==1063988== Profiling result:
-//             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
-//                    20.26%  137.925s    262004  526.42us  517.37us  550.90us  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_00103aad_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
-//
-        const int knotCount = (dim-2)/3 - 2;
+        // CUDA.  This is benchmarked at 0.526 ms per call.
+        //
+        // PROFILED aspen 2024/05/26 -- 8:00am (~190 it/sec)
+        // LTS/Issue510/AtomicOperationsOnHosts w/ GundamInputsOA2021
+        // commit 5e9415e55b258d3d82d562942f03ac07c9937528
+        //
+        // ==1063988== Profiling result:
+        //             Type  Time(%)      Time     Calls       Avg       Min       Max  Name
+        //                    20.26%  137.925s    262004  526.42us  517.37us  550.90us  _ZN4hemi6KernelIN78_GLOBAL__N__54_tmpxft_00103aad_00000000_7_WeightGeneralSpline_cpp1_ii_220155e217HEMISplinesKernelEJPdPKdS5_S5_S5_PKiPKsS7_mEEEvT_DpT0_
+        //
+        const int knotCount = (dim-2)/3 - 1;
         int ix = 0;
+        // Define a non-branching conditional to update the offset.  The &&
+        // becomes a "multiplication", and the conditional update becomes a
+        // "swap-if-true" (which doesn't branch).
 #define CHECK_OFFSET(ioff)  if ((ix+ioff < knotCount) && (x > data[2+3*(ix+ioff)+2])) ix += ioff
         CHECK_OFFSET(16);
         CHECK_OFFSET(8);
         CHECK_OFFSET(4);
         CHECK_OFFSET(2);
         CHECK_OFFSET(1);
+#undef CHECK_OFFSET
 #endif
 
         const double x1 = data[2+3*ix+2];


### PR DESCRIPTION
This now uses the last knot of the spline that was skipped due to
an off-by-one bug.  See Issue #913 on the main branch for more details.

Closes #919 