### PR TITLE
Tests/symmetric spline unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
   set(GUNDAM_TESTS_ARGUMENT "-f")
 endif(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
 
-set(DEV_WITHOUT_GUNDAM_TESTS ON) # Should be off by default.
+set(DEV_WITHOUT_GUNDAM_TESTS OFF) # Should be off by default.
 # Run the main executable test scripts.  These are relatively slow, so they
 if( NOT DEV_WITHOUT_GUNDAM_TESTS )
   add_test(

--- a/tests/GTests/unitTest_CalculateGeneralSpline.cpp
+++ b/tests/GTests/unitTest_CalculateGeneralSpline.cpp
@@ -31,10 +31,11 @@ namespace {
         spline.SetLineWidth(5);
         spline.SetLineColor(kRed);
         spline.Draw("same");
+        double splineRange = spline.GetXmax()-spline.GetXmin();
         const int nKnots = spline.GetNp();
         EXPECT_EQ(nKnots,graph.GetN()) << testName << ": Knots match graph";
         const int dim = 3*nKnots + 2;
-        double data[dim];
+        std::vector<double> data(dim);
         data[0] = -3.0;
         data[1] = 0.0;
         std::cout << testName << ": Number of knots " << nKnots << std::endl;
@@ -54,19 +55,19 @@ namespace {
             spline.GetKnot(knot,xxx,yyy);
             double splineValue = spline.Eval(xxx);
             double calcValue
-                = CalculateGeneralSpline(xxx,-100.0, 100.0,
-                                         data, dim);
+                = CalculateGeneralSpline(xxx,-1.0E+20, 1.0+20,
+                                         data.data(), dim);
             EXPECT_NEAR(splineValue, calcValue, 1e-5)
                 << testName << ": must match at knots";
         }
         TGraph generalSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin()-1.0;
-             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-0.5*splineRange;
+             xxx<=spline.GetXmax()+0.5*splineRange; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
-                = CalculateGeneralSpline(xxx,-100.0, 100.0,
-                                         data, dim);
+                = CalculateGeneralSpline(xxx,-1.0E+20, 1.0E+20,
+                                         data.data(), dim);
             generalSpline.SetPoint(point++, xxx, calcValue);
             EXPECT_NEAR(splineValue, calcValue, 1E-6)
                 << testName << ": Spline Mismatch at " << xxx << " " << point-1;
@@ -91,7 +92,7 @@ namespace {
         const int nKnots = graph.GetN();
         EXPECT_EQ(nKnots,graph.GetN()) << testName << ": Knots match graph";
         const int dim = 3*nKnots + 2;
-        double data[dim];
+        std::vector<double> data(dim);
         data[0] = -3.0;
         data[1] = 0.0;
         std::cout << testName << ": Number of knots " << nKnots << std::endl;
@@ -119,8 +120,8 @@ namespace {
             double xxx = graph.GetPointX(knot);
             double yyy = graph.GetPointY(knot);
             double calcValue
-                = CalculateGeneralSpline(xxx,-100.0, 100.0,
-                                         data, dim);
+                = CalculateGeneralSpline(xxx,-1.0E+20, 1.0E+20,
+                                         data.data(), dim);
             EXPECT_NEAR(yyy, calcValue, 1e-5)
                 << testName << ": must match at knots";
         }
@@ -129,8 +130,8 @@ namespace {
         for (double xxx = spline.GetXmin();
              xxx<=spline.GetXmax(); xxx += 0.01) {
             double calcValue
-                = CalculateGeneralSpline(xxx,-100.0, 100.0,
-                                         data, dim);
+                = CalculateGeneralSpline(xxx,-1.0E+20, 1.0E+20,
+                                         data.data(), dim);
             generalSpline.SetPoint(point++, xxx, calcValue);
         }
         generalSpline.SetLineWidth(3);
@@ -154,9 +155,18 @@ TEST(GeneralSpline,MatchTSpline3ThreeKnot) {
     testGeneralSpline(graph,"MatchTSpline3ThreeKnot",true);
 }
 
+TEST(GeneralSpline,MatchTSpline3ThreeKnotSymmetric) {
+    // Define a TSpline3 and make sure that GeneralSpline reproduces it
+    TGraph graph;
+    graph.SetPoint(0,-3.0, 5.5);
+    graph.SetPoint(1, 0.0, 1.0);
+    graph.SetPoint(2, 3.0, 5.5);
+    testGeneralSpline(graph,"MatchTSpline3ThreeKnotSymmetric",true);
+}
+
 TEST(GeneralSpine,MatchTSpline3FiveKnot) {
     // Define a TGraph and make sure that GeneralSpline reproduces it
-    TGraph graph(3);
+    TGraph graph(5);
     graph.SetPoint(0,-3.0, 0.0);
     graph.SetPoint(1, 0.1, 1.0);
     graph.SetPoint(2, 2.3, 3.5);

--- a/tests/GTests/unitTest_CalculateUniformSpline.cpp
+++ b/tests/GTests/unitTest_CalculateUniformSpline.cpp
@@ -31,6 +31,7 @@ namespace {
         spline.SetLineWidth(5);
         spline.SetLineColor(kRed);
         spline.Draw("same");
+        double splineRange = spline.GetXmax()-spline.GetXmin();
         const int nKnots = spline.GetNp();
         EXPECT_EQ(nKnots,graph.GetN()) << testName << ": Knots match graph";
         const int dim = 2*nKnots + 2;
@@ -55,18 +56,18 @@ namespace {
             spline.GetKnot(knot,xxx,yyy);
             double splineValue = spline.Eval(xxx);
             double calcValue
-                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                = CalculateUniformSpline(xxx,-1.0E+20, 1.0E+20,
                                          data.data(), dim);
             EXPECT_NEAR(splineValue, calcValue, 1e-5)
                 << testName << ": must match at knots";
         }
         TGraph uniformSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin()-1.0;
-             xxx<=spline.GetXmax()+1.0; xxx += 0.01) {
+        for (double xxx = spline.GetXmin()-0.5*splineRange;
+             xxx<=spline.GetXmax()+0.5*splineRange; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
-                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                = CalculateUniformSpline(xxx,-1.0E+20, 1.0E+20,
                                          data.data(), dim);
             uniformSpline.SetPoint(point++, xxx, calcValue);
             EXPECT_NEAR(splineValue, calcValue, 1E-6)
@@ -122,7 +123,7 @@ namespace {
             double xxx = graph.GetPointX(knot);
             double yyy = graph.GetPointY(knot);
             double calcValue
-                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                = CalculateUniformSpline(xxx,-1.0E+20, 1.0E+20,
                                          data.data(), dim);
             EXPECT_NEAR(yyy, calcValue, 1e-5)
                 << testName << ": must match at knots";
@@ -132,7 +133,7 @@ namespace {
         for (double xxx = spline.GetXmin();
              xxx<=spline.GetXmax(); xxx += 0.01) {
             double calcValue
-                = CalculateUniformSpline(xxx,-100.0, 100.0,
+                = CalculateUniformSpline(xxx,-1.0E+20, 1.0E+20,
                                          data.data(), dim);
             uniformSpline.SetPoint(point++, xxx, calcValue);
         }
@@ -157,9 +158,18 @@ TEST(UniformSpline,MatchTSpline3ThreeKnot) {
     testUniformSpline3(graph,"MatchTSpline3ThreeKnot",true);
 }
 
+TEST(UniformSpline,MatchTSpline3ThreeKnotSymmetric) {
+    // Define a TSpline3 and make sure that UniformSpline reproduces it
+    TGraph graph;
+    graph.SetPoint(0,-3.0, 5.5);
+    graph.SetPoint(1, 0.0, 1.0);
+    graph.SetPoint(2, 3.0, 5.5);
+    testUniformSpline3(graph,"MatchTSpline3ThreeKnotSymmetric",true);
+}
+
 TEST(UniformSpine,MatchTSpline3FiveKnot) {
-    // Define a TGraph and make sure that UniformSpline reproduces it
-    TGraph graph(3);
+    // Define a TGraph and make sure that GeneralSpline reproduces it
+    TGraph graph(5);
     graph.SetPoint(0,-1.0, 0.0);
     graph.SetPoint(1, 0.0, 1.0);
     graph.SetPoint(2, 1.0, 3.5);

--- a/tests/regular-tests/100CheckCompactSpline.C
+++ b/tests/regular-tests/100CheckCompactSpline.C
@@ -197,6 +197,35 @@ int main() {
     }
 #endif
 
+#define TEST6
+#ifdef TEST6
+    {
+        // Test non-linear interpolation between three points
+        int nData = 3;
+        double data[] = {-1.0,  2.0/(nData-1), 1.0, 0.0, 1.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -2.0; x <= 2.0; x += 0.1) {
+            double v0 = CalculateCompactSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateCompactSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Inverted symmetric tolerance (test 6) (X=" << x << ")";
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckCompactSpline6.pdf");
+        gPad->Print("100CheckCompactSpline6.png");
+    }
+#endif
+
     return status;
 }
 exit(main());

--- a/tests/regular-tests/100CheckGeneralSpline.C
+++ b/tests/regular-tests/100CheckGeneralSpline.C
@@ -98,7 +98,7 @@ int main() {
 #ifdef TEST2
     {
         // Define a TGraph and make sure that GeneralSpline reproduces it
-        TGraph graph(3);
+        TGraph graph;
         graph.SetPoint(0,-3.0, 0.0);
         graph.SetPoint(1, 0.1, 1.0);
         graph.SetPoint(2, 2.3, 3.5);
@@ -170,7 +170,7 @@ int main() {
         double data[dim];
         data[0] = -3.0;
         data[1] = 0.0;
-        std::cout << "Test1: Number of knots " << nKnots << std::endl;
+        std::cout << "Test4: Number of knots " << nKnots << std::endl;
         for (int knot = 0; knot < nKnots; ++knot) {
             double xx;
             double yy;
@@ -183,20 +183,77 @@ int main() {
         }
         TGraph generalSpline;
         int point = 0;
-        for (double xxx = spline.GetXmin() - 2.0;
-             xxx<=spline.GetXmax() + 2.0; xxx += 0.01) {
+        double delta = spline.GetXmax()-spline.GetXmin();
+        for (double xxx = spline.GetXmin() - 0.5*delta;
+             xxx<=spline.GetXmax() + 0.5*delta; xxx += 0.01) {
             double splineValue = spline.Eval(xxx);
             double calcValue
                 = CalculateGeneralSpline(xxx,-100.0, 100.0,
                                        data, dim);
             generalSpline.SetPoint(point++, xxx, calcValue);
-            TOLERANCE("Test3: Spline Mismatch", splineValue, calcValue, 1E-6);
+            TOLERANCE("Test4: Spline Mismatch", splineValue, calcValue, 1E-6);
         }
         generalSpline.SetLineWidth(3);
         generalSpline.SetLineColor(kGreen);
         generalSpline.Draw("same");
         gPad->Print("100CheckGeneralSpline3.pdf");
         gPad->Print("100CheckGeneralSpline3.png");
+    }
+#endif
+
+#define TEST4
+#ifdef TEST4
+    {
+        // Define a 3 point symmetric spline
+        // Define a TSpline3 and make sure that GeneralSpline reproduces it
+        TGraph graph;
+        graph.SetPoint(0,-1.0, 1.0);
+        graph.SetPoint(1, 0.0, 0.0);
+        graph.SetPoint(2, 1.0, 1.0);
+        TSpline3 spline("splineOfGraph",&graph);
+        const int nKnots = spline.GetNp();
+        const int dim = 3*nKnots + 2;
+        double data[dim];
+        data[0] = -3.0;
+        data[1] = 0.0;
+        std::cout << "Test4: Number of knots " << nKnots << std::endl;
+        for (int knot = 0; knot < nKnots; ++knot) {
+            double xx;
+            double yy;
+            double ss;
+            spline.GetKnot(knot,xx,yy);
+            ss = spline.Derivative(xx);
+            data[2+3*knot+0] = yy;
+            data[2+3*knot+1] = ss;
+            data[2+3*knot+2] = xx;
+        }
+        TGraph generalSpline;
+        TGraph rootSpline;
+        int point = 0;
+        double delta = spline.GetXmax()-spline.GetXmin();
+        for (double xxx = spline.GetXmin() - 0.5*delta;
+             xxx<=spline.GetXmax() + 0.5*delta; xxx += 0.01) {
+            double splineValue = spline.Eval(xxx);
+            double calcValue
+                = CalculateGeneralSpline(xxx,-100.0, 100.0,
+                                       data, dim);
+            rootSpline.SetPoint(point,xxx,splineValue);
+            generalSpline.SetPoint(point++, xxx, calcValue);
+            TOLERANCE("Test4: Spline Mismatch", splineValue, calcValue, 1E-6);
+        }
+        generalSpline.SetLineWidth(5);
+        generalSpline.SetLineColor(kGreen);
+        generalSpline.Draw("AC");
+        spline.SetLineWidth(3);
+        spline.SetLineColor(kRed);
+        spline.Draw("same");
+        rootSpline.SetLineWidth(2);
+        rootSpline.SetLineColor(kRed);
+        rootSpline.Draw("same");
+        graph.SetLineStyle(2);
+        graph.Draw("same");
+        gPad->Print("100CheckGeneralSpline4.pdf");
+        gPad->Print("100CheckGeneralSpline4.png");
     }
 #endif
 

--- a/tests/regular-tests/100CheckMonotonicSpline.C
+++ b/tests/regular-tests/100CheckMonotonicSpline.C
@@ -72,7 +72,8 @@ int main() {
 #define TEST2
 #ifdef TEST2
     {
-        // Test non-linear interpolation between three points
+        // Test non-linear interpolation between three points with maximum at
+        // zero.
         int nData = 3;
         double data[] = {-1.0,  2.0/(nData-1), 0.0, 1.0, 0.0};
         std::unique_ptr<TGraph> data1(new TGraph());
@@ -194,6 +195,41 @@ int main() {
         data1->Draw("*,same");
         gPad->Print("100CheckMonotonicSpline5.pdf");
         gPad->Print("100CheckMonotonicSpline5.png");
+    }
+#endif
+
+#define TEST6
+#ifdef TEST6
+    {
+        // Test non-linear interpolation between three points with minimum at
+        // zero.
+        int nData = 3;
+        double data[] = {-1.0,  2.0/(nData-1), 1.0, 0.0, 1.0};
+        std::unique_ptr<TGraph> data1(new TGraph());
+        for (int p=0; p<nData; ++p) {
+            double x = data[0] + p*data[1];
+            double y = data[p+2];
+            data1->SetPoint(p,x,y);
+        }
+        std::unique_ptr<TGraph> graph1(new TGraph());
+        int p = 0;
+        for (double x = -2.0; x <= 2.0; x += 0.1) {
+            double v0 = CalculateMonotonicSpline(x, -10.0, 10.0, data, nData);
+            double v1 = CalculateMonotonicSpline(-x, -10.0, 10.0, data, nData);
+            std::ostringstream tmp;
+            tmp << "Symmetric tolerance (test 6) (X=" << x << ")";
+            if (v0 < 0.0) {
+                std::cout << "FAIL: " << tmp.str()
+                          << " -- Spline must be positive (Y=" << v0 << ")"
+                          << std::endl;
+            }
+            TOLERANCE(tmp.str(), v0, v1, 1E-6);
+            graph1->SetPoint(p++,x,v0);
+        }
+        graph1->Draw("AC");
+        data1->Draw("*,same");
+        gPad->Print("100CheckMonotonicSpline6.pdf");
+        gPad->Print("100CheckMonotonicSpline6.png");
     }
 #endif
 


### PR DESCRIPTION
Add a test for a common special case with a mirrored "linear" response between zero and one that is represented by a spline to make sure that the slope at zero is zero.  This is done since the likelihood has to be smooth and the mirrored linear response gives a cusp at zero.  This produces plots that are suitable for the FAQ.