### PR TITLE
Fix: GTest with fetch content

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 	path = submodules/simple-cpp-cmd-line-parser
 	url = https://github.com/gundam-organization/simple-cpp-cmd-line-parser.git
 	branch = main
-[submodule "submodules/googletest"]
-	path = submodules/googletest
-	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,7 @@
 # GUNDAM project CMake main file
 #
 
-# cmake_minimum_required() should be called prior to this top-level project()
-# 3.10 minimum a priori. Taking a lower version as min will make recent CMake
-# version complain about the deprecation version older than 3.10.
-# Might require higher version for specific features.
+# 3.11 minimum required for FetchContent
 cmake_minimum_required( VERSION 3.10 FATAL_ERROR )
 
 # Define project

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -131,13 +131,16 @@ include_directories( ${ROOT_INCLUDE_DIR} )
 ####################
 
 cmessage( STATUS "Looking for JSON install..." )
-FetchContent_Declare(
-  nlohmann_json
-  GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.11.3
-  FIND_PACKAGE_ARGS NAMES nlohmann_json 
-)
-set(DeclaredContent ${DeclaredContent} nlohmann_json)
+find_package(nlohmann_json)
+if( NOT nlohmann_json_FOUND )
+  cmessage( WARNING "System nlohmann_json package not found")
+  FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+  )
+  set(DeclaredContent ${DeclaredContent} nlohmann_json)
+endif( NOT nlohmann_json_FOUND )
 
 
 ####################
@@ -172,13 +175,16 @@ link_libraries( ${YAML_CPP_LIBRARIES} )
 ####################
 # GoogleTest
 ####################
-FetchContent_Declare(
-  GTest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG v1.16.0
-  FIND_PACKAGE_ARGS NAMES GTest
-)
-set(DeclaredContent ${DeclaredContent} GTest)
+find_package(GTest)
+if( NOT GTest_FOUND )
+  cmessage( WARNING "System GTest package not found")
+  FetchContent_Declare(
+    GTest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.16.0
+  )
+  set(DeclaredContent ${DeclaredContent} GTest)
+endif( NOT GTest_FOUND )
 
 ####################
 # CUDA (optional)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,6 +1,11 @@
 message("")
-cmessage( WARNING "Checking dependencies...")
+cmessage( STATUS "Checking dependencies...")
 
+include( FetchContent )
+
+# A string with all the packages to be made available after everything
+# is declared
+set(DeclaredContent "")
 
 ##########
 # ROOT
@@ -126,22 +131,13 @@ include_directories( ${ROOT_INCLUDE_DIR} )
 ####################
 
 cmessage( STATUS "Looking for JSON install..." )
-find_package( nlohmann_json QUIET )
-
-if( nlohmann_json_FOUND )
-  cmessage( STATUS "nlohmann JSON library found.")
-  link_libraries( nlohmann_json::nlohmann_json )
-else()
-  cmessage( ALERT "nlohmann JSON library not found. Using fetch content... (CMake version >= 3.11)")
-  cmake_minimum_required( VERSION 3.11 FATAL_ERROR )
-  include( FetchContent )
-
-  FetchContent_Declare( json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz )
-  FetchContent_MakeAvailable( json )
-
-  include_directories( ${nlohmann_json_SOURCE_DIR}/include )
-  cmessage( STATUS "nlohmann JSON library fetched: ${nlohmann_json_SOURCE_DIR}/include")
-endif()
+FetchContent_Declare(
+  nlohmann_json
+  GIT_REPOSITORY https://github.com/nlohmann/json.git
+  GIT_TAG v3.11.3
+  FIND_PACKAGE_ARGS NAMES nlohmann_json 
+)
+set(DeclaredContent ${DeclaredContent} nlohmann_json)
 
 
 ####################
@@ -173,6 +169,16 @@ include_directories( ${YAMLCPP_INCLUDE_DIR} )
 link_libraries( ${YAML_CPP_LIBRARIES} )
 
 
+####################
+# GoogleTest
+####################
+FetchContent_Declare(
+  GTest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.16.0
+  FIND_PACKAGE_ARGS NAMES GTest
+)
+set(DeclaredContent ${DeclaredContent} GTest)
 
 ####################
 # CUDA (optional)
@@ -196,6 +202,7 @@ if( WITH_CUDA_LIB )
         # After cmake 3.23, this can be set to all or all-major
         set( CMAKE_CUDA_ARCHITECTURES all )
       else()
+        cmessage( WARNING "Force CUDA architecture to 52 (deprecated)")
         set( CMAKE_CUDA_ARCHITECTURES 52 )
       endif()
     endif()
@@ -209,3 +216,12 @@ else( WITH_CUDA_LIB )
     cmessage( STATUS "WITH_CACHE_MANAGER=ON: CUDA support disabled. Use -D WITH_CUDA_LIB=ON if needed." )
   endif()
 endif( WITH_CUDA_LIB )
+
+if (DeclaredContent)
+  # Make any FetchContent available.  Fetched packages should be added
+  # to the local DeclaredContent variable.
+  cmessage(STATUS "Declared Content ${DeclaredContent}")
+  FetchContent_MakeAvailable(${DeclaredContent})
+else()
+  cmessage(WARNING "No content declared")
+endif (DeclaredContent)

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -23,7 +23,6 @@ endfunction( checkSubmodule )
 checkSubmodule( cpp-generic-toolbox )
 checkSubmodule( simple-cpp-logger )
 checkSubmodule( simple-cpp-cmd-line-parser )
-checkSubmodule( googletest )
 
 ## Add the CmdLineParser
 # Reproduce needed parts of the simple-cpp-cmd-line-parser CMakeLists.txt
@@ -74,6 +73,3 @@ else()
   add_definitions( -D LOGGER_ENABLE_COLORS_ON_USER_HEADER=1 )
 endif()
 
-## GoogleTest as a subdirectory.  This makes it available to the
-# rest of the build using the "include(GoogleTest)" cmake module.
-add_subdirectory( ${CMAKE_SOURCE_DIR}/submodules/googletest )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
   set(GUNDAM_TESTS_ARGUMENT "-f")
 endif(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
 
-set(DEV_WITHOUT_GUNDAM_TESTS ON) # Should be off by default.
+set(DEV_WITHOUT_GUNDAM_TESTS OFF) # Should be off by default.
 # Run the main executable test scripts.  These are relatively slow, so they
 if( NOT DEV_WITHOUT_GUNDAM_TESTS )
   add_test(
@@ -31,7 +31,7 @@ if( NOT DEV_WITHOUT_GUNDAM_TESTS )
     COMMAND "sh" "-c" "(cd ${CMAKE_SOURCE_DIR}/tests && ./gundam-tests.sh ${GUNDAM_TESTS_ARGUMENT} -a ${CMAKE_BINARY_DIR}/Testing/gundam-tests.$(date +%Y-%m-%d-%H%M%S) )"
   )
 else()
-  cmessage( WARN "GUNDAM executable tests not being run.")
+  cmessage( WARNING "GUNDAM executable tests (gundam-tests.sh) not being run.")
 endif( NOT DEV_WITHOUT_GUNDAM_TESTS )
 
 if( WITH_GOOGLE_TEST )


### PR DESCRIPTION
Get access to the `googletest` libraries using FetchContent which first tries to get the library using find_package, but will download and compile it when a system version is not found.  This is intended to fix the problems that we saw on MacOS and CCLyon which were caused because the system version of GTest was different than the submodule version that had been included in GUNDAM.

Closes #931 
Closes #935