### PR TITLE
Add tests for the 1D spline dials

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -228,8 +228,6 @@ endif( WITH_CUDA_LIB )
 if (DeclaredContent)
   # Make any FetchContent available.  Fetched packages should be added
   # to the local DeclaredContent variable.
-  cmessage(STATUS "Declared Content ${DeclaredContent}")
+  cmessage(WARNING "FetchContest: Will build ${DeclaredContent}")
   FetchContent_MakeAvailable(${DeclaredContent})
-else()
-  cmessage(WARNING "No content declared")
 endif (DeclaredContent)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -175,16 +175,18 @@ link_libraries( ${YAML_CPP_LIBRARIES} )
 ####################
 # GoogleTest
 ####################
-find_package(GTest)
-if( NOT GTest_FOUND )
-  cmessage( WARNING "System GTest package not found")
-  FetchContent_Declare(
-    GTest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.16.0
-  )
-  set(DeclaredContent ${DeclaredContent} GTest)
-endif( NOT GTest_FOUND )
+if( WITH_GOOGLE_TEST )
+  find_package(GTest)
+  if( NOT GTest_FOUND )
+    cmessage( WARNING "System GTest package not found")
+    FetchContent_Declare(
+      GTest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG v1.16.0
+    )
+    set(DeclaredContent ${DeclaredContent} GTest)
+  endif( NOT GTest_FOUND )
+endif( WITH_GOOGLE_TEST )
 
 ####################
 # CUDA (optional)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -228,6 +228,6 @@ endif( WITH_CUDA_LIB )
 if (DeclaredContent)
   # Make any FetchContent available.  Fetched packages should be added
   # to the local DeclaredContent variable.
-  cmessage(WARNING "FetchContest: Will build ${DeclaredContent}")
+  cmessage(WARNING "FetchContent: Will build ${DeclaredContent}")
   FetchContent_MakeAvailable(${DeclaredContent})
 endif (DeclaredContent)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -21,6 +21,11 @@ option( WITH_MINUIT2_MISSING "Allow MINUIT2 to be missing" OFF )
 option( WITH_PYTHON_INTERFACE "Compile the python interface modules" OFF )
 option( WITH_TESTS "Build CMake tests." ON )
 option( WITH_GOOGLE_TEST "Enable GoogleTest (disable at your own risk).." ON )
+option( WITH_INTERFACE_TEST "Enable gundam-test.sh interface tests" ON)
+option( WITH_FAST_TEST "Enable the fast unit tests (ideal for CI)" ON)
+option( WITH_REGULAR_TEST "Enable the regular unit tests" OFF)
+option( WITH_EXTENDED_TEST "Enable the regular unit tests" OFF)
+option( WITH_SLOW_TEST "Enable the regular unit tests" OFF)
 
 # compile helper
 option( YAMLCPP_DIR "Set custom path to yaml-cpp lib." OFF )
@@ -114,4 +119,20 @@ if(WITH_PYTHON_INTERFACE)
   set( PYBIND11_PYTHON_VERSION 3.11.6 )
   set( PYBIND11_FINDPYTHON ON )
   find_package( pybind11 REQUIRED )
+endif()
+
+# Ensure that all lower level tests are on
+if(WITH_SLOW_TEST AND NOT WITH_EXTENDED_TEST)
+  cmessage( WARNING "Extended tests enabled by slow tests")
+  set(WITH_EXTENDED_TEST ON )
+endif()
+
+if(WITH_EXTENDED_TEST AND NOT WITH_REGULAR_TEST)
+  cmessage( WARNING "Regular tests enabled by extended tests")
+  set(WITH_REGULAR_TEST ON)
+endif()
+
+if(WITH_REGULAR_TEST AND NOT WITH_FAST_TEST)
+  cmessage( WARNING "Fast tests enabled by regular tests")
+  set(WITH_FAST_TEST ON)
 endif()

--- a/cmake/scripts/gundam-build.sh
+++ b/cmake/scripts/gundam-build.sh
@@ -102,7 +102,7 @@ while [ "x${1}" != "x" ]; do
             echo Continue on errors
             MAKE_OPTIONS=" -k ${MAKE_OPTIONS}"
             ;;
-        test|ctest) # test
+        te*|cte*) # test or ctest
             shift
             echo Run tests
             RUN_TEST="yes"

--- a/cmake/scripts/gundam-build.sh
+++ b/cmake/scripts/gundam-build.sh
@@ -124,9 +124,10 @@ while [ "x${1}" != "x" ]; do
             echo
             exit 0
             ;;
-        -D*) # Add definitions
+        -D*) # Add definitions and force cmake
             echo Add $1
             DEFINES="${DEFINES} ${1}"
+            FORCE_CMAKE="yes"
             shift
             ;;
         *)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ if( WITH_GOOGLE_TEST )
   list(APPEND FAST_TESTS GTests/unitTest_CalculateBilinearInterpolation.cpp)
   list(APPEND FAST_TESTS GTests/unitTest_CalculateBicubicSpline.cpp)
   list(APPEND FAST_TESTS GTests/unitTest_ApplyMonotonicCondition.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_DialUtils.cpp)
 
   # Compile the fast test executable, but only add them to ctest if
   # WITH_FAST_TEST is on. This should NOT be "optimized" to skip compilation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,43 +20,78 @@ enable_testing()
 # tests, and "-s" for slow tests.
 #
 if(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
-  set(GUNDAM_TESTS_ARGUMENT "-f")
+  if(WITH_SLOW_TEST)
+    set(GUNDAM_TESTS_ARGUMENT "-s")
+  elseif(WITH_EXTENDED_TEST)
+    set(GUNDAM_TESTS_ARGUMENT "-e")
+  elseif(WITH_REGULAR_TEST)
+    set(GUNDAM_TESTS_ARGUMENT "-r")
+  else()
+    set(GUNDAM_TESTS_ARGUMENT "-f")
+  endif()
 endif(NOT DEFINED GUNDAM_TESTS_ARGUMENT OR GUNDAM_TESTS_ARGUMENT STREQUAL "")
 
-set(DEV_WITHOUT_GUNDAM_TESTS OFF) # Should be off by default.
 # Run the main executable test scripts.  These are relatively slow, so they
-if( NOT DEV_WITHOUT_GUNDAM_TESTS )
+if(WITH_INTERFACE_TEST)
+  cmessage( STATUS "gundam-tests.sh run using: ${GUNDAM_TESTS_ARGUMENT}")
   add_test(
     NAME gundam-tests
     COMMAND "sh" "-c" "(cd ${CMAKE_SOURCE_DIR}/tests && ./gundam-tests.sh ${GUNDAM_TESTS_ARGUMENT} -a ${CMAKE_BINARY_DIR}/Testing/gundam-tests.$(date +%Y-%m-%d-%H%M%S) )"
   )
-else()
-  cmessage( WARNING "GUNDAM executable tests (gundam-tests.sh) not being run.")
-endif( NOT DEV_WITHOUT_GUNDAM_TESTS )
+else(WITH_INTERFACE_TEST)
+  cmessage( WARNING "WITH_INTERFACE_TEST is OFF: gundam-tests.sh will be skipped")
+endif(WITH_INTERFACE_TEST)
 
 if( WITH_GOOGLE_TEST )
   ## Compiled unit tests using GoogleTest.
   include(GoogleTest)
-
   cmessage( STATUS "Compiling google tests" )
-  add_executable(gundamGTest_unitTest.exe
-    GTests/unitTest_JointProbability.cpp
-    GTests/unitTest_CalculateCompactSpline.cpp
-    GTests/unitTest_CalculateMonotonicSpline.cpp
-    GTests/unitTest_CalculateGraph.cpp
-    GTests/unitTest_CalculateGeneralSpline.cpp
-    GTests/unitTest_CalculateUniformSpline.cpp
-    GTests/unitTest_CalculateBilinearInterpolation.cpp
-    GTests/unitTest_CalculateBicubicSpline.cpp
-    GTests/unitTest_ApplyMonotonicCondition.cpp
-  )
-  target_link_libraries(gundamGTest_unitTest.exe GTest::gtest_main)
-  target_link_libraries(gundamGTest_unitTest.exe GundamFitter)
-  gtest_discover_tests(gundamGTest_unitTest.exe)
+
+  ## Create a list of all of the fast tests.  These are always
+  ## compiled, and are run when WITH_FAST_TEST is on.  The fast tests
+  ## are run during CI, so all of them should finish quickly, and we
+  ## should limit the total number.
+  list(APPEND FAST_TESTS "")
+  list(APPEND FAST_TESTS GTests/unitTest_JointProbability.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateCompactSpline.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateMonotonicSpline.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateGraph.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateGeneralSpline.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateUniformSpline.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateBilinearInterpolation.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_CalculateBicubicSpline.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_ApplyMonotonicCondition.cpp)
+
+  # Compile the fast test executable, but only add them to ctest if
+  # WITH_FAST_TEST is on. This should NOT be "optimized" to skip compilation
+  # when WITH_FAST_TEST is off.
+  if(FAST_TESTS)
+    add_executable(gundamGTest_fastTest.exe ${FAST_TESTS})
+    target_link_libraries(gundamGTest_fastTest.exe GTest::gtest_main)
+    target_link_libraries(gundamGTest_fastTest.exe GundamFitter)
+    if(WITH_FAST_TEST)
+      gtest_discover_tests(gundamGTest_fastTest.exe PROPERTIES LABELS unit)
+    endif(WITH_FAST_TEST)
+  endif(FAST_TESTS)
+
+  ## Create a list of all of the regular tests.  These are always
+  ## compiled and are run when WITH_REGULAR_TEST is on.
+  list(APPEND REGULAR_TESTS "")
+
+  # Compile the regular test executable, but only add them to ctest if
+  # WITH_REGULAR_TEST is on. This should NOT be "optimized" to skip
+  # compilation when WITH_REGULAR_TEST is off.
+  if(REGULAR_TESTS)
+    add_executable(gundamGTest_regularTest.exe ${REGULAR_TESTS})
+    target_link_libraries(gundamGTest_regularTest.exe GTest::gtest_main)
+    target_link_libraries(gundamGTest_regularTest.exe GundamFitter)
+    if(WITH_REGULAR_TEST)
+      gtest_discover_tests(gundamGTest_regularTest.exe PROPERTIES LABELS unit)
+    endif(WITH_REGULAR_TEST)
+  endif(REGULAR_TESTS)
 
   if( WITH_CACHE_MANAGER )
     # Setup the hemi test suite for the host
-
     add_executable(gundamGTest_host.exe
       GTests/hemiArrayTest.cpp
       GTests/hemiExecutionPolicyTest.cpp
@@ -65,7 +100,9 @@ if( WITH_GOOGLE_TEST )
     target_link_libraries(gundamGTest_host.exe GTest::gtest_main)
     target_link_libraries(gundamGTest_host.exe GundamCacheManager)
     target_compile_definitions(gundamGTest_host.exe PUBLIC HEMI_CUDA_DISABLE)
-    gtest_discover_tests(gundamGTest_host.exe)
+    if (WITH_REGULAR_TEST)
+      gtest_discover_tests(gundamGTest_host.exe PROPERTIES LABELS host)
+    endif(WITH_REGULAR_TEST)
 
     if(CMAKE_CUDA_COMPILER)
       # Setup the hemi test suite for the device.
@@ -77,15 +114,17 @@ if( WITH_GOOGLE_TEST )
         GTests/hemiExternals.cpp)
       target_link_libraries(gundamGTest_device.exe GTest::gtest_main)
       target_link_libraries(gundamGTest_device.exe GundamCacheManager)
-      gtest_discover_tests(gundamGTest_device.exe)
+      if(WITH_REGULAR_TEST)
+        gtest_discover_tests(gundamGTest_device.exe PROPERTIES LABELS device)
+      endif(WITH_REGULAR_TEST)
     endif(CMAKE_CUDA_COMPILER)
 
   else( WITH_CACHE_MANAGER )
 
-    cmessage( WARNING "WITH_CACHE_MANAGER is set to false. Skipping Cache::Manager test executables." )
+    cmessage( WARNING "WITH_CACHE_MANAGER is OFF. Skip Cache::Manager tests." )
 
   endif( WITH_CACHE_MANAGER )
 
-else(WITH_GOOGLE_TEST)
-  cmessage( WARNING "GoogleTests are not used and some unit tests are skipped")
-endif()
+else( WITH_GOOGLE_TEST )
+  cmessage( WARNING "GoogleTest disabled so some unit tests will be skipped")
+endif( WITH_GOOGLE_TEST )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ if( WITH_GOOGLE_TEST )
   list(APPEND FAST_TESTS GTests/unitTest_CalculateBicubicSpline.cpp)
   list(APPEND FAST_TESTS GTests/unitTest_ApplyMonotonicCondition.cpp)
   list(APPEND FAST_TESTS GTests/unitTest_DialUtils.cpp)
+  list(APPEND FAST_TESTS GTests/unitTest_DialDefinitions.cpp)
 
   # Compile the fast test executable, but only add them to ctest if
   # WITH_FAST_TEST is on. This should NOT be "optimized" to skip compilation

--- a/tests/GTests/unitTest_DialDefinitions.cpp
+++ b/tests/GTests/unitTest_DialDefinitions.cpp
@@ -1,0 +1,250 @@
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include <TGraph.h>
+#include <TSpline.h>
+#include <TPad.h>
+
+////////////////////////////////////////////////////////////////////////
+// Test the DialDefinitions
+#include "DialUtils.h"
+#include "DialInputBuffer.h"
+#include "CompactSpline.h"
+#include "MonotonicSpline.h"
+#include "GeneralSpline.h"
+#include "UniformSpline.h"
+#include "CalculateCompactSpline.h"
+
+TEST(DialDefinitions,CompactSplineTruncated) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Create an input buffer for the parameters
+    DialInputBuffer buffer;
+    buffer.getInputBuffer().resize(1);
+
+    // Create the dial.
+    CompactSpline dial;
+    dial.buildDial(graph1Points);
+    dial.setAllowExtrapolation(false);
+
+    // Setup for the reference value calculation
+    std::vector<double> data{dial.getDialData()};
+    auto reference =
+        [&](double r) -> double {
+            return CalculateCompactSpline(r,0.0, 1000.0, data.data(),
+                                          data.size()-2);
+        };
+
+    double range = graph1Points.back().x - graph1Points.front().x;
+    for (double r = graph1Points.front().x;
+         r <= graph1Points.back().x;
+         r = r + range/100.0) {
+        buffer.getInputBuffer()[0] = r;
+        double d = dial.evalResponse(buffer);
+        double c = reference(r);
+        EXPECT_NEAR(d,c,1e-9) << "Must match CalculateCompactSpline";
+    }
+
+    // Check that the extrapolation is truncated at the minimum knot.
+    {
+        double minKnot = graph1Points.front().x;
+        double truncVal = graph1Points.front().y;
+        for (double r = minKnot - range; r < minKnot; r = r + range/1000.0) {
+            buffer.getInputBuffer()[0] = r;
+            double d = dial.evalResponse(buffer);
+            EXPECT_NEAR(d,truncVal,1E-9)
+                << "Extrapolation must truncate at " << r;
+        }
+    }
+
+    // Check that extrapolation is truncated at the maximum knot
+    {
+        double maxKnot = graph1Points.back().x;
+        double truncVal = graph1Points.back().y;
+        for (double r = maxKnot; r < maxKnot + range; r = r + range/1000.0) {
+            buffer.getInputBuffer()[0] = r;
+            double d = dial.evalResponse(buffer);
+            EXPECT_NEAR(d,truncVal,1E-9)
+                << "Extrapolation must truncate at " << r;
+        }
+    }
+
+
+}
+
+TEST(DialDefinitions,CompactSplineExtrapolated) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Create an input buffer for the parameters
+    DialInputBuffer buffer;
+    buffer.getInputBuffer().resize(1);
+
+    // Create the dial.
+    CompactSpline dial;
+    dial.buildDial(graph1Points);
+    dial.setAllowExtrapolation(true);
+
+    // Setup for the reference value calculation
+    std::vector<double> data{dial.getDialData()};
+    auto reference =
+        [&](double r) -> double {
+            return CalculateCompactSpline(r,0.0, 1000.0, data.data(),
+                                          data.size()-2);
+        };
+
+    double range = graph1Points.back().x - graph1Points.front().x;
+    for (double r = graph1Points.front().x - range;
+         r <= graph1Points.back().x + range;
+         r = r + range/100.0) {
+        buffer.getInputBuffer()[0] = r;
+        double d = dial.evalResponse(buffer);
+        double c = reference(r);
+        EXPECT_NEAR(d,c,1e-9) << "Must match CalculateCompactSpline";
+    }
+}
+
+TEST(DialDefinitions,MonotonicSpline) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Create an input buffer for the parameters
+    DialInputBuffer buffer;
+    buffer.getInputBuffer().resize(1);
+
+    // Create the reference dial.
+    CompactSpline reference;
+    reference.buildDial(graph1Points);
+    reference.setAllowExtrapolation(false);
+
+    // Create the dial to be tested.  The monotonic spline should match
+    // Catmull Rom for these points.
+    MonotonicSpline dial;
+    dial.buildDial(graph1Points);
+    dial.setAllowExtrapolation(false);
+
+    double range = graph1Points.back().x - graph1Points.front().x;
+    for (double r = graph1Points.front().x - range;
+         r <= graph1Points.back().x + range;
+         r = r + range/100.0) {
+        buffer.getInputBuffer()[0] = r;
+        double d = dial.evalResponse(buffer);
+        double c = reference.evalResponse(buffer);
+        EXPECT_NEAR(d,c,1e-9) << "Must match CompactSpline";
+    }
+}
+
+TEST(DialDefinitions,CatmullRomGeneral) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Create an input buffer for the parameters
+    DialInputBuffer buffer;
+    buffer.getInputBuffer().resize(1);
+
+    // Create the dial.
+    CompactSpline reference;
+    reference.buildDial(graph1Points);
+    reference.setAllowExtrapolation(false);
+
+    DialPoints catmullRomPoints{graph1Points};
+    DialUtils::fillCatmullRomSlopes(catmullRomPoints);
+    GeneralSpline dial;
+    dial.buildDial(catmullRomPoints);
+    dial.setAllowExtrapolation(false);
+
+    double range = graph1Points.back().x - graph1Points.front().x;
+    for (double r = graph1Points.front().x - range;
+         r <= graph1Points.back().x + range;
+         r = r + range/100.0) {
+        buffer.getInputBuffer()[0] = r;
+        double d = dial.evalResponse(buffer);
+        double c = reference.evalResponse(buffer);
+        EXPECT_NEAR(d,c,1e-9) << "Must match CompactSpline";
+    }
+}
+
+TEST(DialDefinitions,CatmullRomUniform) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Create an input buffer for the parameters
+    DialInputBuffer buffer;
+    buffer.getInputBuffer().resize(1);
+
+    // Create the dial.
+    CompactSpline reference;
+    reference.buildDial(graph1Points);
+    reference.setAllowExtrapolation(false);
+
+    DialPoints catmullRomPoints{graph1Points};
+    DialUtils::fillCatmullRomSlopes(catmullRomPoints);
+    UniformSpline dial;
+    dial.buildDial(catmullRomPoints);
+    dial.setAllowExtrapolation(false);
+
+    double range = graph1Points.back().x - graph1Points.front().x;
+    for (double r = graph1Points.front().x - range;
+         r <= graph1Points.back().x + range;
+         r = r + range/100.0) {
+        buffer.getInputBuffer()[0] = r;
+        double d = dial.evalResponse(buffer);
+        double c = reference.evalResponse(buffer);
+        EXPECT_NEAR(d,c,1e-9) << "Must match CalculateCompactSpline";
+    }
+}
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// End:

--- a/tests/GTests/unitTest_DialUtils.cpp
+++ b/tests/GTests/unitTest_DialUtils.cpp
@@ -1,0 +1,119 @@
+#include <iostream>
+#include <string>
+#include <memory>
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include <TGraph.h>
+#include <TSpline.h>
+#include <TPad.h>
+
+////////////////////////////////////////////////////////////////////////
+// Test the DialUtils
+#include "DialUtils.h"
+
+TEST(DialUtils,GetPointList) {
+    // Test the getPointList functions
+    TGraph graph1;
+    graph1.SetPoint(0,-1.0, 1.0);
+    graph1.SetPoint(1, 0.0, 0.0);
+    graph1.SetPoint(2, 1.0, 1.0);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    // Check that the graph got copied.
+    EXPECT_GT(graph1Points.size(), 0)
+        << "Must have points in graph";
+    for (std::size_t i = 0; i<graph1.GetN(); ++i) {
+        EXPECT_NEAR(graph1.GetX()[i], graph1Points[i].x, 1e-6)
+            << "X Value should match for index " << i;
+        EXPECT_NEAR(graph1.GetY()[i], graph1Points[i].y, 1e-6)
+            << "Y Value should match for index " << i;
+    }
+
+    // Check that a spline get's copied.
+    TSpline3 spline1("spline1",&graph1);
+    DialPoints spline1Points = DialUtils::getPointList(&spline1);
+    EXPECT_GT(spline1Points.size(), 0)
+        << "Must have points in spline";
+    EXPECT_EQ(graph1Points.size(), spline1Points.size())
+        << "Spline and graph must have same number of points";
+
+    for (std::size_t i = 0; i<graph1Points.size(); ++i) {
+        EXPECT_NEAR(graph1Points[i].x, spline1Points[i].x,1E-6)
+            << "X values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].y, spline1Points[i].y,1E-6)
+            << "Y values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].slope, spline1Points[i].slope,1E-6)
+            << "Slope values must be near to each other";
+    }
+
+    TObject* object1 = &graph1;
+    DialPoints object1Points = DialUtils::getPointList(object1);
+
+    EXPECT_EQ(graph1Points.size(), object1Points.size())
+        << "Must have the same number of points";
+
+    for (std::size_t i = 0; i<graph1Points.size(); ++i) {
+        EXPECT_NEAR(graph1Points[i].x, object1Points[i].x,1E-6)
+            << "X values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].y, object1Points[i].y,1E-6)
+            << "Y values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].slope, object1Points[i].slope,1E-6)
+            << "Slope values must be near to each other";
+    }
+
+    DialPoints slope1Points = DialUtils::getPointListNoSlope(&graph1);
+
+    EXPECT_EQ(graph1Points.size(), slope1Points.size())
+        << "Must have the same number of points";
+
+    for (std::size_t i = 0; i<graph1Points.size(); ++i) {
+        EXPECT_NEAR(graph1Points[i].x, slope1Points[i].x,1E-6)
+            << "X values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].y, slope1Points[i].y,1E-6)
+            << "Y values must be near to each other";
+        EXPECT_NEAR(0.0, slope1Points[i].slope,1E-6)
+            << "Slope values must be near to each other";
+    }
+}
+
+TEST(DialUtils,SlopeCalculations) {
+    TGraph graph1;
+    graph1.SetPoint(0,-3.0, 1.75);
+    graph1.SetPoint(1,-2.0, 1.5);
+    graph1.SetPoint(2,-1.0, 1.0);
+    graph1.SetPoint(3, 0.0, 0.0);
+    graph1.SetPoint(4, 1.0, 1.0);
+    graph1.SetPoint(5, 2.0, 1.5);
+    graph1.SetPoint(6, 3.0, 1.75);
+
+    using DialPoints = std::vector<DialUtils::DialPoint>;
+    DialPoints graph1Points = DialUtils::getPointList(&graph1);
+
+    DialPoints akima1Points{graph1Points};
+    DialUtils::fillAkimaSlopes(akima1Points);
+    for (std::size_t i = 0; i<graph1Points.size(); ++i) {
+        EXPECT_NEAR(graph1Points[i].x, akima1Points[i].x,1E-6)
+            << "X values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].y, akima1Points[i].y,1E-6)
+            << "Y values must be near to each other";
+    }
+
+    DialPoints catmullRom1Points{graph1Points};
+    DialUtils::fillCatmullRomSlopes(catmullRom1Points);
+    for (std::size_t i = 0; i<graph1Points.size(); ++i) {
+        EXPECT_NEAR(graph1Points[i].x, catmullRom1Points[i].x,1E-6)
+            << "X values must be near to each other";
+        EXPECT_NEAR(graph1Points[i].y, catmullRom1Points[i].y,1E-6)
+            << "Y values must be near to each other";
+    }
+
+}
+
+// Local Variables:
+// mode:c++
+// c-basic-offset:4
+// End:


### PR DESCRIPTION
Most of the 1D spline dials now have tests which are complementary to the lower level Calculate(Blah) tests.  The main numeric tests are done in the lower level tests, so these concentrate on making sure that the dials correctly pass the Calculate(Blah) results.

As part of the work, `tests/CMakeList.txt` has been restructured to more robustly handle the unit tests, and there are options to control which tests get run by default (the default is "WITH_FAST_TEST=on") 