### PR TITLE
Fix wrong event.h header include from YAML

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -168,7 +168,7 @@ if( "${YAMLCPP_INCLUDE_DIR} " STREQUAL " ")
   cmessage(FATAL_ERROR "empty YAMLCPP_INCLUDE_DIR returned.")
 endif()
 set(YAML_CPP_LIBRARIES ${YAMLCPP_LIBRARY})
-include_directories( ${YAMLCPP_INCLUDE_DIR} )
+include_directories( SYSTEM ${YAMLCPP_INCLUDE_DIR} )
 link_libraries( ${YAML_CPP_LIBRARIES} )
 
 

--- a/src/CacheManager/CMakeLists.txt
+++ b/src/CacheManager/CMakeLists.txt
@@ -61,7 +61,7 @@ endif( USE_STATIC_LINKS )
 
 # Make sure the current directories are available for the later
 # compilation.
-target_include_directories( GundamCacheManager PUBLIC
+target_include_directories( GundamCacheManager BEFORE PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries( GundamCacheManager PUBLIC

--- a/src/DatasetManager/CMakeLists.txt
+++ b/src/DatasetManager/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
   add_library( ${LIB_NAME} SHARED ${SRCFILES} )
 endif()
 
-target_include_directories(${LIB_NAME} PUBLIC
+target_include_directories(${LIB_NAME} BEFORE PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries( ${LIB_NAME}
@@ -41,4 +41,3 @@ target_link_libraries( ${LIB_NAME}
 install( TARGETS ${LIB_NAME} DESTINATION lib )
 #Can uncomment this to install the headers... but is it really neccessary?
 # install(FILES ${HEADERS} DESTINATION include)
-

--- a/src/DialDictionary/CMakeLists.txt
+++ b/src/DialDictionary/CMakeLists.txt
@@ -75,7 +75,9 @@ else()
 endif()
 
 target_include_directories(
-    ${LIB_NAME} PUBLIC
+    ${LIB_NAME}
+    BEFORE
+    PUBLIC
     DialEngine/include
     DialFactories/include
     DialDefinitions/include

--- a/src/Fitter/CMakeLists.txt
+++ b/src/Fitter/CMakeLists.txt
@@ -15,7 +15,9 @@ else()
 endif()
 
 target_include_directories(
-    ${LIB_NAME} PUBLIC
+    ${LIB_NAME}
+    BEFORE
+    PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/Engine/include
     ${CMAKE_CURRENT_SOURCE_DIR}/Minimizer/include
 )

--- a/src/ParametersManager/CMakeLists.txt
+++ b/src/ParametersManager/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
   add_library(${LIB_NAME} SHARED ${SRCFILES})
 endif()
 
-target_include_directories(${LIB_NAME} PUBLIC
+target_include_directories(${LIB_NAME} BEFORE PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Dependencies
@@ -53,4 +53,3 @@ install(TARGETS ${LIB_NAME} DESTINATION lib)
 #        COMPONENT
 #        libraries
 #)
-

--- a/src/Propagator/CMakeLists.txt
+++ b/src/Propagator/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 
 
 target_include_directories( GundamPropagator
+    BEFORE
     PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/src/PythonInterface/CMakeLists.txt
+++ b/src/PythonInterface/CMakeLists.txt
@@ -9,6 +9,9 @@ pybind11_add_module( ${LIB_NAME} ${SRC_FILE_LIST} )
 
 target_include_directories( ${LIB_NAME} PUBLIC
     ${PYBIND11_INCLUDE_DIRS}
+)
+
+target_include_directories( ${LIB_NAME} BEFORE PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
@@ -28,6 +31,5 @@ target_link_libraries( ${LIB_NAME} PUBLIC
 #)
 #
 install( TARGETS ${LIB_NAME} DESTINATION lib )
-
 
 

--- a/src/SamplesManager/CMakeLists.txt
+++ b/src/SamplesManager/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 target_include_directories(
     ${LIB_NAME}
+    BEFORE
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
@@ -37,4 +38,3 @@ target_link_libraries(
 #set_target_properties( ${LIB_NAME} PROPERTIES VERSION "${GUNDAM_VERSION_STRING}")
 
 install(TARGETS ${LIB_NAME} DESTINATION lib)
-

--- a/src/StatisticalInference/CMakeLists.txt
+++ b/src/StatisticalInference/CMakeLists.txt
@@ -14,7 +14,9 @@ else()
 endif()
 
 target_include_directories(
-    ${LIB_NAME} PUBLIC
+    ${LIB_NAME}
+    BEFORE
+    PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/JointProbability/include
     ${CMAKE_CURRENT_SOURCE_DIR}/Likelihood/include
 )

--- a/src/Utils/CMakeLists.txt
+++ b/src/Utils/CMakeLists.txt
@@ -50,7 +50,7 @@ include_directories( ${CMAKE_BINARY_DIR}/generated/ ) # version header
 
 # Make sure the current directories are available for the later
 # compilation.
-target_include_directories( GundamUtils PUBLIC
+target_include_directories( GundamUtils BEFORE PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_BINARY_DIR}/generated
 )


### PR DESCRIPTION
On my macOS/homebrew setup, for some reason the compiler chooses the `event.h` within the YAML library. In the sample library we expect the compiler to find the proper `Event.h`.

This PR specifies explicitly that the `Event.h` should used in priority.