### PR TITLE
Fix Issue 928: Reorganize fixed and frozen

### DIFF
--- a/docs/configuration/Parameter.md
+++ b/docs/configuration/Parameter.md
@@ -20,8 +20,9 @@ covariance.
 | priorType                        | string       | penalty shape (Gaussian/Flat)                              | Gaussian     |
 | priorValue                       | double       | prior value (expected)                                     | nan          |
 | isEnabled                        | bool         | use parameter in the propagator                            | true         |
-| isPenaltyDisabled                | bool         | Fix value, do not use in fit, and strip from covariance    | false        |
-| isFrozen                         | bool         | Fix the parameter in the fit (e.g. set MINUIT FixVariable) | false        |
+| isPenaltyDisabled                | bool         | Fix value in fit, and strip from covariance                | false        |
+| isFixed                          | bool         | Fix the parameter in the fit (e.g. set MINUIT FixVariable) | false        |
+| isFrozen                         | bool         | DEPRECATED: use isFixed                                    | false        |
 | isThrown                         | bool         | throw parameter when generating toy                        | false        |
 | parameterStepSize                | double       | Expected scale of the variation                            | 1.0          |
 | parameterLimits                  | pair(double) | minimum and maximum for the domain                         | [-inf, +inf] |

--- a/docs/configuration/Parameter.md
+++ b/docs/configuration/Parameter.md
@@ -13,22 +13,23 @@ covariance.
 
 ### Config options
 
-| Option                           | Type         | Description                           | Default      |
-|----------------------------------|--------------|---------------------------------------|--------------|
-| name                             | string       | define parameter with name (expected) |              |
-| parameterIndex                   | int          | define parameter with index           |              |
-| priorType                        | string       | penalty shape (Gaussian/Flat)         | Gaussian     |
-| priorValue                       | double       | prior value (expected)                | nan          |
-| isEnabled                        | bool         | use parameter in the propagator       | true         |
-| isFixed                          | bool         | use parameter in the propagator       | false        |
-| isThrown                         | bool         | throw parameter when generating toy   | false        |
-| parameterStepSize                | double       | Expected scale of the variation       | 1.0          |
-| parameterLimits                  | pair(double) | minimum and maximum for the domain    | [-inf, +inf] |
-| physicalLimits                   | pair(double) | minimum and maximum physical range    | [-inf, +inf] |
-| throwLimits                      | pair(double) | minimum and maximum range to throw    | [-inf, +inf] |
-| mirrorRange                      | pair(double) | boundaries for internal mirroring     | [-inf, +inf] |
-| cyclicRange                      | pair(double) | boundaries of the cyclic interval     | [-inf, +inf] |
-| [dialSetDefinitions](Dial.md   ) | list(json)   | Only for single dimension dials       |              |
+| Option                           | Type         | Description                                                | Default      |
+|----------------------------------|--------------|------------------------------------------------------------|--------------|
+| name                             | string       | define parameter with name (expected)                      |              |
+| parameterIndex                   | int          | define parameter with index                                |              |
+| priorType                        | string       | penalty shape (Gaussian/Flat)                              | Gaussian     |
+| priorValue                       | double       | prior value (expected)                                     | nan          |
+| isEnabled                        | bool         | use parameter in the propagator                            | true         |
+| isPenaltyDisabled                | bool         | Fix value, do not use in fit, and strip from covariance    | false        |
+| isFrozen                         | bool         | Fix the parameter in the fit (e.g. set MINUIT FixVariable) | false        |
+| isThrown                         | bool         | throw parameter when generating toy                        | false        |
+| parameterStepSize                | double       | Expected scale of the variation                            | 1.0          |
+| parameterLimits                  | pair(double) | minimum and maximum for the domain                         | [-inf, +inf] |
+| physicalLimits                   | pair(double) | minimum and maximum physical range                         | [-inf, +inf] |
+| throwLimits                      | pair(double) | minimum and maximum range to throw                         | [-inf, +inf] |
+| mirrorRange                      | pair(double) | boundaries for internal mirroring                          | [-inf, +inf] |
+| cyclicRange                      | pair(double) | boundaries of the cyclic interval                          | [-inf, +inf] |
+| [dialSetDefinitions](Dial.md   ) | list(json)   | Only for single dimension dials                            |              |
 
 #### dialSetDefinitions
 

--- a/src/Fitter/Engine/src/FitterEngine.cpp
+++ b/src/Fitter/Engine/src/FitterEngine.cpp
@@ -174,7 +174,7 @@ void FitterEngine::initializeImpl(){
       thrownParameterValues.emplace_back();
 
       for( auto& par : parSet.getParameterList() ){
-        if( not par.isEnabled() or par.isFixed() or par.isFree() ) continue;
+        if( not par.isEnabled() or par.isPenaltyDisabled() or par.isFree() ) continue;
         leavesList.emplace_back(GenericToolbox::generateCleanBranchName(par.getTitle()) + "/D");
         thrownParameterValues.back().writeRawData(par.getThrowValue());
       }
@@ -545,7 +545,7 @@ void FitterEngine::runPcaCheck(){
       ssPrint << "(" << par.getParameterIndex()+1 << "/" << parList.size() << ") +1 std-dev on " << parSet.getName() + "/" + par.getTitle();
 
       if( fixNextEigenPars ){
-        par.setIsFixed(true);
+        par.setIsPenaltyDisabled(true);
 #ifndef NOCOLOR
         std::string red(GenericToolbox::ColorCodes::redBackground);
         std::string rst(GenericToolbox::ColorCodes::resetColor);
@@ -557,7 +557,7 @@ void FitterEngine::runPcaCheck(){
         continue;
       }
 
-      if( par.isEnabled() and not par.isFixed() ){
+      if( par.isEnabled() and not par.isPenaltyDisabled() ){
         double currentParValue = par.getParameterValue();
         par.setParameterValue( currentParValue + par.getStdDevValue() );
 
@@ -603,7 +603,7 @@ void FitterEngine::runPcaCheck(){
         LogAlert << color << ssPrint.str() << rst << std::endl;
 
         if( fixParPca ){
-          par.setIsFixed(true); // ignored in the Chi2 computation of the parSet
+          par.setIsPenaltyDisabled(true); // ignored in the Chi2 computation of the parSet
           if( parSet.isEnableEigenDecomp() and _fixGhostEigenParametersAfterFirstRejected_ ){
             fixNextEigenPars = true;
           }

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -62,7 +62,7 @@ void MinimizerBase::initializeImpl(){
     for( auto& par : parSet.getEffectiveParameterList() ){
       if( par.isEnabled() and not par.isPenaltyDisabled() ) {
         _minimizerParameterPtrList_.emplace_back( &par );
-        if( par.isFree() and not par.isFrozen() ){ _nbFreeParameters_++; }
+        if( par.isFree() and not par.isFixed() ){ _nbFreeParameters_++; }
       }
     }
   }
@@ -195,7 +195,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
 
       size_t nbValidPars = std::count_if(
               _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
-              [](const Parameter* par_){ return not ( par_->isPenaltyDisabled() or par_->isFrozen() or not par_->isEnabled() ); } );
+              [](const Parameter* par_){ return not ( par_->isPenaltyDisabled() or par_->isFixed() or not par_->isEnabled() ); } );
 
       std::stringstream ssHeader;
       ssHeader << std::endl << GenericToolbox::getNowDateString("%Y.%m.%d %H:%M:%S");
@@ -346,8 +346,8 @@ void MinimizerBase::printParameters(){
       std::string statusStr;
 
       if( not par.isEnabled() ) { continue; }
-      else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
-      else if( par.isFrozen() )  { statusStr = "Frozen (penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+      else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (penalty not applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+      else if( par.isFixed() )  { statusStr = "Fixed (penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
       else                      {
         statusStr = Parameter::PriorType::toString(par.getPriorType()) + " Prior";
         if(par.getPriorType()==Parameter::PriorType::Flat) colorStr = GenericToolbox::ColorCodes::blueLightText;

--- a/src/Fitter/Minimizer/src/MinimizerBase.cpp
+++ b/src/Fitter/Minimizer/src/MinimizerBase.cpp
@@ -60,7 +60,7 @@ void MinimizerBase::initializeImpl(){
   _minimizerParameterPtrList_.reserve( getLikelihoodInterface().getNbParameters() );
   for( auto& parSet : getModelPropagator().getParametersManager().getParameterSetsList() ){
     for( auto& par : parSet.getEffectiveParameterList() ){
-      if( par.isEnabled() and not par.isFixed() ) {
+      if( par.isEnabled() and not par.isPenaltyDisabled() ) {
         _minimizerParameterPtrList_.emplace_back( &par );
         if( par.isFree() and not par.isFrozen() ){ _nbFreeParameters_++; }
       }
@@ -195,7 +195,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
 
       size_t nbValidPars = std::count_if(
               _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
-              [](const Parameter* par_){ return not ( par_->isFixed() or par_->isFrozen() or not par_->isEnabled() ); } );
+              [](const Parameter* par_){ return not ( par_->isPenaltyDisabled() or par_->isFrozen() or not par_->isEnabled() ); } );
 
       std::stringstream ssHeader;
       ssHeader << std::endl << GenericToolbox::getNowDateString("%Y.%m.%d %H:%M:%S");
@@ -253,7 +253,7 @@ double MinimizerBase::evalFit( const double* parArray_ ){
         ssHeader << std::endl << std::setprecision(1) << std::scientific << std::showpos;
         int nParPerLine{0};
         for( auto* fitPar : _minimizerParameterPtrList_ ){
-          if( fitPar->isFixed() ) continue;
+          if( fitPar->isPenaltyDisabled() ) continue;
           if( curParSet != fitPar->getOwner()->getName() ){
             if( not curParSet.empty() ) ssHeader << std::endl;
             curParSet = fitPar->getOwner()->getName();
@@ -346,7 +346,7 @@ void MinimizerBase::printParameters(){
       std::string statusStr;
 
       if( not par.isEnabled() ) { continue; }
-      else if( par.isFixed() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+      else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
       else if( par.isFrozen() )  { statusStr = "Frozen (penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
       else                      {
         statusStr = Parameter::PriorType::toString(par.getPriorType()) + " Prior";

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -239,7 +239,7 @@ void RootMinimizer::minimize(){
   /// Apply the frozen state to the root minimizer variable definitions
   for( std::size_t iFitPar = 0 ; iFitPar < getMinimizerFitParameterPtr().size() ; iFitPar++ ){
     auto& fitPar = *(getMinimizerFitParameterPtr()[iFitPar]);
-    if (fitPar.isFrozen()) {
+    if (fitPar.isFixed()) {
       if (fitPar.isEigen()) {
         LogAlert << "Eigen decomposed parameters cannot be frozen, and remain free"
                  << std::endl;

--- a/src/Fitter/Minimizer/src/RootMinimizer.cpp
+++ b/src/Fitter/Minimizer/src/RootMinimizer.cpp
@@ -582,7 +582,7 @@ double RootMinimizer::evalFit(const double *parArray_){
       // minimum, every parameter get updated
       size_t nbValidPars = std::count_if(
               _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
-              [](const Parameter* par_){ return not ( par_->isFixed() or not par_->isEnabled() ); } );
+              [](const Parameter* par_){ return not ( par_->isPenaltyDisabled() or not par_->isEnabled() ); } );
       size_t nParUpdated = std::count_if(
               _minimizerParameterPtrList_.begin(), _minimizerParameterPtrList_.end(),
               [](const Parameter* par_){ return par_->gotUpdated(); } );
@@ -1121,7 +1121,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
         t << "Prior Fraction" << GenericToolbox::TablePrinter::NextLine;
 
         for( const auto& par : parList_ ){
-          if( par.isEnabled() and not par.isFixed() ){
+          if( par.isEnabled() and not par.isPenaltyDisabled() ){
             double priorFraction = std::sqrt((*covMatrix_)[par.getParameterIndex()][par.getParameterIndex()]) / par.getStdDevValue();
             std::stringstream ss;
 #ifndef NOCOLOR
@@ -1190,7 +1190,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
                               [par.getParameterIndex()]));
               }
               preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), par.getPriorValue() );
-              if( par.isEnabled() and not par.isFixed() and not par.isFree() ){
+              if( par.isEnabled() and not par.isPenaltyDisabled() and not par.isFree() ){
                 preFitErrorHist->SetBinError( 1 + par.getParameterIndex(), par.getStdDevValue() );
               }
             }
@@ -1209,7 +1209,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
               }
 
               preFitErrorHist->SetBinContent( 1 + par.getParameterIndex(), 0 );
-              if( par.isEnabled() and not par.isFixed() and not par.isFree() ){
+              if( par.isEnabled() and not par.isPenaltyDisabled() and not par.isFree() ){
                 preFitErrorHist->SetBinError( 1 + par.getParameterIndex(), 1 );
               }
             } // norm
@@ -1243,7 +1243,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
               b.SetFillColor(kGreen-10);
               freeParBoxes.emplace_back(b);
             }
-            else if( par.isFixed() or not par.isEnabled() ){
+            else if( par.isPenaltyDisabled() or not par.isEnabled() ){
               b.SetFillColor(kGray);
               fixedParBoxes.emplace_back(b);
             }
@@ -1360,7 +1360,7 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
 
       // need to restore the non-fitted values before the base swap
       for( auto& eigenPar : *parList ){
-        if( eigenPar.isEnabled() and not eigenPar.isFixed() ) continue;
+        if( eigenPar.isEnabled() and not eigenPar.isPenaltyDisabled() ) continue;
         (*covMatrix)[eigenPar.getParameterIndex()][eigenPar.getParameterIndex()] = eigenPar.getStdDevValue() * eigenPar.getStdDevValue();
       }
 
@@ -1377,11 +1377,11 @@ void RootMinimizer::writePostFitData( TDirectory* saveDir_) {
       covMatrix = std::make_unique<TMatrixD>(int(parList->size()), int(parList->size()));
       int iStripped{-1};
       for( auto& iPar : *parList ){
-        if( iPar.isFixed() or not iPar.isEnabled() ) continue;
+        if( iPar.isPenaltyDisabled() or not iPar.isEnabled() ) continue;
         iStripped++;
         int jStripped{-1};
         for( auto& jPar : *parList ){
-          if( jPar.isFixed() or not jPar.isEnabled() ) continue;
+          if( jPar.isPenaltyDisabled() or not jPar.isEnabled() ) continue;
           jStripped++;
           (*covMatrix)[iPar.getParameterIndex()][jPar.getParameterIndex()] = (*originalStrippedCovMatrix)[iStripped][jStripped];
         }

--- a/src/Fitter/Minimizer/src/SimpleMcmc.cpp
+++ b/src/Fitter/Minimizer/src/SimpleMcmc.cpp
@@ -1007,7 +1007,7 @@ void SimpleMcmc::minimize() {
     for (const Parameter& iPar : parSet.getParameterList()) {
       ++countParameters;
       parameterIndex.push_back(iPar.getParameterIndex());
-      parameterFixed.push_back(iPar.isFixed());
+      parameterFixed.push_back(iPar.isPenaltyDisabled());
       parameterEnabled.push_back(iPar.isEnabled());
       parameterName.push_back(iPar.getTitle());
       parameterPrior.push_back(iPar.getPriorValue());

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -39,7 +39,7 @@ public:
   void setName(const std::string &name){ _name_ = name; }
   void setPriorType(PriorType priorType){ _priorType_ = priorType; }
   void setIsEnabled(bool isEnabled){ _isEnabled_ = isEnabled; }
-  void setIsFixed(bool isFixed){ _isFixed_ = isFixed; }
+  void setIsPenaltyDisabled(bool isPenaltyDisabled){ _isPenaltyDisabled_ = isPenaltyDisabled; }
   void setIsFrozen(bool isFrozen){ _isFrozen_ = isFrozen; }
   void setIsEigen(bool isEigen){ _isEigen_ = isEigen; }
   void setIsFree(bool isFree){ _isFree_ = isFree; }
@@ -93,12 +93,12 @@ public:
   /// The parameter has no constrains applied.
   [[nodiscard]] auto isFree() const{ return _isFree_; }
 
-  /// The parameter is fixed, and does not enter into the penalty term.
-  /// Although it is removed from the covariance and its value is used for the
-  /// reweighting.  This constrasts with a frozen variable where the value of
-  /// the variable will not be changed by the fit, but the variable is used to
-  /// calculate the penalty term.
-  [[nodiscard]] auto isFixed() const{ return _isFixed_; }
+  /// The parameter penalty is disabled and does not enter into the penalty
+  /// term.  Although it is removed from the covariance and its value is used
+  /// for the reweighting.  This constrasts with a frozen variable where the
+  /// value of the variable will not be changed by the fit, but the variable
+  /// is used to calculate the penalty term.
+  [[nodiscard]] auto isPenaltyDisabled() const{ return _isPenaltyDisabled_; }
 
   /// The parameter affects the likelihood, and is included in the penalty,
   /// but should not be varied as part of the fit.  A common usage is for
@@ -121,8 +121,8 @@ public:
 
   /// A random value should be generated for this parameter when the parameter
   /// set is thrown.  Notice that a "frozen" parameter is thrown, while a
-  /// "fixed" parameter is not.
-  [[nodiscard]] auto isThrown() const{ return _isThrown_ and _isEnabled_ and not _isFixed_; }
+  /// "isPenaltyDisabled" parameter is not.
+  [[nodiscard]] auto isThrown() const{ return _isThrown_ and _isEnabled_ and not _isPenaltyDisabled_; }
 
   [[nodiscard]] bool isCyclic() const;
   [[nodiscard]] auto gotUpdated() const { return _gotUpdated_; }
@@ -233,7 +233,7 @@ public:
 private:
   // Parameters
   bool _isEnabled_{true};
-  bool _isFixed_{false};
+  bool _isPenaltyDisabled_{false};
   bool _isFrozen_{false};
   bool _isEigen_{false};
   bool _isFree_{false};

--- a/src/ParametersManager/include/Parameter.h
+++ b/src/ParametersManager/include/Parameter.h
@@ -40,7 +40,7 @@ public:
   void setPriorType(PriorType priorType){ _priorType_ = priorType; }
   void setIsEnabled(bool isEnabled){ _isEnabled_ = isEnabled; }
   void setIsPenaltyDisabled(bool isPenaltyDisabled){ _isPenaltyDisabled_ = isPenaltyDisabled; }
-  void setIsFrozen(bool isFrozen){ _isFrozen_ = isFrozen; }
+  void setIsFixed(bool isFixed){_isFixed_ = isFixed; }
   void setIsEigen(bool isEigen){ _isEigen_ = isEigen; }
   void setIsFree(bool isFree){ _isFree_ = isFree; }
   void setIsThrown(bool isThrown){ _isThrown_ = isThrown; }
@@ -108,7 +108,7 @@ public:
   /// does not change the behavior toy throws, or the Bayesian MCMC analysis
   /// [where the absolute value of the LLH isn't meaningful].  Note:
   /// Parameters in an eigen decomposed parameter set cannot be frozen.
-  [[nodiscard]] auto isFrozen() const{ return _isFrozen_; }
+  [[nodiscard]] auto isFixed() const{ return _isFixed_; }
 
   /// When a parameter set is eigen decomposed, a set of "fake" parameters is
   /// created for each of the eigen vectors.  This is true when the current
@@ -234,7 +234,7 @@ private:
   // Parameters
   bool _isEnabled_{true};
   bool _isPenaltyDisabled_{false};
-  bool _isFrozen_{false};
+  bool _isFixed_{false};
   bool _isEigen_{false};
   bool _isFree_{false};
   bool _isThrown_{true};

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -18,7 +18,7 @@ void Parameter::prepareConfig(ConfigReader& config_){
     {"isEnabled"},
     {"priorValue"},
     {"isPenaltyDisabled"},
-    {"isFrozen"},
+    {"isFixed", {"isFrozen"}},
     {"isThrown"},
     {"parameterStepSize"},
     {"parameterIndex"},
@@ -49,7 +49,7 @@ void Parameter::configureImpl(){
   }
 
   _config_.fillValue(_isPenaltyDisabled_, "isPenaltyDisabled");
-  _config_.fillValue(_isFrozen_, "isFrozen");
+  _config_.fillValue(_isFixed_, "isFixed");
   _config_.fillValue(_isThrown_, "isThrown");
   _config_.fillValue(_stepSize_, "parameterStepSize");
   _config_.fillValue(_physicalLimits_, "physicalLimits");

--- a/src/ParametersManager/src/Parameter.cpp
+++ b/src/ParametersManager/src/Parameter.cpp
@@ -17,7 +17,7 @@ void Parameter::prepareConfig(ConfigReader& config_){
     {"name", {"parameterName"}},
     {"isEnabled"},
     {"priorValue"},
-    {"isFixed"},
+    {"isPenaltyDisabled"},
     {"isFrozen"},
     {"isThrown"},
     {"parameterStepSize"},
@@ -48,7 +48,7 @@ void Parameter::configureImpl(){
     }
   }
 
-  _config_.fillValue(_isFixed_, "isFixed");
+  _config_.fillValue(_isPenaltyDisabled_, "isPenaltyDisabled");
   _config_.fillValue(_isFrozen_, "isFrozen");
   _config_.fillValue(_isThrown_, "isThrown");
   _config_.fillValue(_stepSize_, "parameterStepSize");

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -331,7 +331,7 @@ void ParameterSet::processCovarianceMatrix(){
       _eigenParameterList_[iEigen].setName("eigen");
 
       // fixing all of them by default
-      _eigenParameterList_[iEigen].setIsFixed(true);
+      _eigenParameterList_[iEigen].setIsPenaltyDisabled(true);
       (*eigenState)[iEigen] = 0;
       (*_eigenValuesInv_)[iEigen] = 1./(*_eigenValues_)[iEigen];
 
@@ -360,7 +360,7 @@ void ParameterSet::processCovarianceMatrix(){
       }
 
       // if we reach this point, the eigen value is accepted
-      _eigenParameterList_[iEigen].setIsFixed( false );
+      _eigenParameterList_[iEigen].setIsPenaltyDisabled( false );
       (*eigenState)[iEigen] = 1.;
       eigenCumulative += (*_eigenValues_)[iEigen];
       _nbEnabledEigen_++;
@@ -473,13 +473,13 @@ void ParameterSet::setValidity(const std::string& validity) {
 void ParameterSet::moveParametersToPrior(){
   if( not isEnableEigenDecomp() ){
     for( auto& par : _parameterList_ ){
-      if( par.isFixed() or par.isFrozen() or not par.isEnabled() ){ continue; }
+      if( par.isPenaltyDisabled() or par.isFrozen() or not par.isEnabled() ){ continue; }
       par.setParameterValue(par.getPriorValue());
     }
   }
   else{
     for( auto& eigenPar : _eigenParameterList_ ){
-      if( eigenPar.isFixed() or not eigenPar.isEnabled() ) continue;
+      if( eigenPar.isPenaltyDisabled() or not eigenPar.isEnabled() ) continue;
       eigenPar.setParameterValue(eigenPar.getPriorValue());
     }
     this->propagateEigenToOriginal();
@@ -750,7 +750,7 @@ void ParameterSet::propagateOriginalToEigen(){
   // First propagate to the buffer
   int iParOffSet{0};
   for( const auto& par : _parameterList_ ){
-    if( par.isFixed() or not par.isEnabled() ) continue;
+    if( par.isPenaltyDisabled() or not par.isEnabled() ) continue;
     (*_originalParBuffer_)[iParOffSet++] = par.getParameterValue();
   }
 
@@ -776,7 +776,7 @@ void ParameterSet::propagateEigenToOriginal(){
   // Propagate back to the real parameters
   int iParOffSet{0};
   for( auto& par : _parameterList_ ){
-    if( par.isFixed() or not par.isEnabled() ) continue;
+    if( par.isPenaltyDisabled() or not par.isEnabled() ) continue;
     par.setParameterValue((*_originalParBuffer_)[iParOffSet++], true);
   }
 }
@@ -803,7 +803,7 @@ std::string ParameterSet::getSummary() const {
           std::string statusStr;
 
           if( not par.isEnabled() ) { continue; }
-          else if( par.isFixed() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+          else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
           else if( par.isFrozen() )  { statusStr = "Frozen (penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
           else if( par.isFree() )   { statusStr = "Free";     colorStr = GenericToolbox::ColorCodes::blueLightText; }
           else                      { statusStr = "Constrained"; }
@@ -987,7 +987,7 @@ double ParameterSet::toRealParValue(double normParValue, const Parameter& par) {
   return normParValue*par.getStdDevValue() + par.getPriorValue();
 }
 bool ParameterSet::isValidCorrelatedParameter(const Parameter& par_){
-  return ( par_.isEnabled() and not par_.isFixed() and not par_.isFree() );
+  return ( par_.isEnabled() and not par_.isPenaltyDisabled() and not par_.isFree() );
 }
 
 void ParameterSet::printConfiguration() const {

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -473,7 +473,7 @@ void ParameterSet::setValidity(const std::string& validity) {
 void ParameterSet::moveParametersToPrior(){
   if( not isEnableEigenDecomp() ){
     for( auto& par : _parameterList_ ){
-      if( par.isPenaltyDisabled() or par.isFrozen() or not par.isEnabled() ){ continue; }
+      if( par.isPenaltyDisabled() or par.isFixed() or not par.isEnabled() ){ continue; }
       par.setParameterValue(par.getPriorValue());
     }
   }
@@ -803,8 +803,8 @@ std::string ParameterSet::getSummary() const {
           std::string statusStr;
 
           if( not par.isEnabled() ) { continue; }
-          else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (prior applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
-          else if( par.isFrozen() )  { statusStr = "Frozen (penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+          else if( par.isPenaltyDisabled() )  { statusStr = "Fixed (w/o penalty)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
+          else if( par.isFixed() )  { statusStr = "Fixed (w/ penalty applied)";    colorStr = GenericToolbox::ColorCodes::yellowLightText; }
           else if( par.isFree() )   { statusStr = "Free";     colorStr = GenericToolbox::ColorCodes::blueLightText; }
           else                      { statusStr = "Constrained"; }
 

--- a/src/ParametersManager/src/ParametersManager.cpp
+++ b/src/ParametersManager/src/ParametersManager.cpp
@@ -57,7 +57,7 @@ void ParametersManager::initializeImpl(){
 
     int nPars{0};
     for( auto& par : parSet.getParameterList() ){
-      if( par.isEnabled() and not par.isFixed() ){ nPars++; }
+      if( par.isEnabled() and not par.isPenaltyDisabled() ){ nPars++; }
     }
 
     nEnabledPars += nPars;
@@ -80,7 +80,7 @@ void ParametersManager::initializeImpl(){
       // LogDebug << "Adding parSet: " << parSet.getName() << " with " << nCov << " cov pars" << std::endl;
       for( auto& par : parSet.getParameterList() ){
         if( not par.isEnabled() ){ continue; }
-        if( par.isFixed() ){ continue; }
+        if( par.isPenaltyDisabled() ){ continue; }
 
         iParIndex++; // will be in the list
 
@@ -94,7 +94,7 @@ void ParametersManager::initializeImpl(){
         int jFree{0};
         for(int jCov = 0 ; jCov < parSet.getPriorCovarianceMatrix()->GetNcols() ; jCov++ ){
           if( not parSet.getParameterList()[jCov].isEnabled() ){ continue; }
-          if( parSet.getParameterList()[jCov].isFixed() ){ continue; }
+          if( parSet.getParameterList()[jCov].isPenaltyDisabled() ){ continue; }
           jParIndex++;
           if( parSet.getParameterList()[jCov].isFree() ){ jFree++; continue; }
           (*_globalCovarianceMatrix_)[parSetOffset + iParIndex][parSetOffset + jParIndex] =
@@ -207,7 +207,7 @@ void ParametersManager::initializeStrippedGlobalCov(){
 
   _strippedParameterList_.clear();
   for( int iGlobPar = 0 ; iGlobPar < _globalCovarianceMatrix_->GetNrows() ; iGlobPar++ ){
-    if( _globalCovParList_[iGlobPar]->isFixed() ){ continue; }
+    if( _globalCovParList_[iGlobPar]->isPenaltyDisabled() ){ continue; }
     if( _globalCovParList_[iGlobPar]->isFree() and (*_globalCovarianceMatrix_)[iGlobPar][iGlobPar] == 0 ){ continue; }
     _strippedParameterList_.emplace_back( _globalCovParList_[iGlobPar] );
   }

--- a/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
+++ b/src/StatisticalInference/Likelihood/src/LikelihoodInterface.cpp
@@ -185,7 +185,7 @@ double LikelihoodInterface::evalPenaltyLikelihood(const ParameterSet& parSet_) c
   if( parSet_.getPriorCovarianceMatrix() != nullptr ){
     if( parSet_.isEnableEigenDecomp() ){
       for( const auto& eigenPar : parSet_.getEigenParameterList() ){
-        if( eigenPar.isFixed() ){ continue; }
+        if( eigenPar.isPenaltyDisabled() ){ continue; }
         buffer += TMath::Sq( (eigenPar.getParameterValue() - eigenPar.getPriorValue()) / eigenPar.getStdDevValue() ) ;
       }
     }

--- a/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
+++ b/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
@@ -385,8 +385,8 @@ void ParameterScanner::generateOneSigmaPlots(TDirectory* saveDir_){
     for( auto& effPar : parSet.getEffectiveParameterList() ){
       if( not effPar.isEnabled() ) continue;
       std::string tag;
-      if( effPar.isPenaltyDisabled() ){ tag += "_FIXED"; }
-      if( effPar.isFrozen() ){ tag += "_FROZEN"; }
+      if( effPar.isPenaltyDisabled() ){ tag += "_NOPENALTY"; }
+      if( effPar.isFixed() ){ tag += "_FIXED"; }
       makeOneSigmaPlotFct(
           effPar,
           GenericToolbox::mkdirTFile(saveDir_, parSet.getName() + "/" + effPar.getTitle() + tag)
@@ -537,9 +537,9 @@ void ParameterScanner::varyEvenRates(const std::vector<double>& paramVariationLi
         if( not par.isEnabled() ) continue;
 
         std::string tag;
-        if( par.isPenaltyDisabled() ){ tag += "_FIXED"; }
+        if( par.isPenaltyDisabled() ){ tag += "_NOPENALTY"; }
         if( par.isFree() ){ tag += "_FREE"; }
-        if( par.isFrozen() ){ tag += "_FROZEN"; }
+        if( par.isFixed() ){ tag += "_FIXED"; }
 
         TDirectory* subDir = GenericToolbox::mkdirTFile(saveDir_, parSet.getName() + "/" + par.getTitle() + tag);
         makeVariedEventRatesFct(par, paramVariationList_, subDir);

--- a/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
+++ b/src/StatisticalInference/Likelihood/src/ParameterScanner.cpp
@@ -385,7 +385,7 @@ void ParameterScanner::generateOneSigmaPlots(TDirectory* saveDir_){
     for( auto& effPar : parSet.getEffectiveParameterList() ){
       if( not effPar.isEnabled() ) continue;
       std::string tag;
-      if( effPar.isFixed() ){ tag += "_FIXED"; }
+      if( effPar.isPenaltyDisabled() ){ tag += "_FIXED"; }
       if( effPar.isFrozen() ){ tag += "_FROZEN"; }
       makeOneSigmaPlotFct(
           effPar,
@@ -537,7 +537,7 @@ void ParameterScanner::varyEvenRates(const std::vector<double>& paramVariationLi
         if( not par.isEnabled() ) continue;
 
         std::string tag;
-        if( par.isFixed() ){ tag += "_FIXED"; }
+        if( par.isPenaltyDisabled() ){ tag += "_FIXED"; }
         if( par.isFree() ){ tag += "_FREE"; }
         if( par.isFrozen() ){ tag += "_FROZEN"; }
 


### PR DESCRIPTION
Based on discussion from the 26 June 2026 developer meeting, the following sequence has been done: 1) rename "isFixed" to "isPenaltyDisabled"; 2) rename "isFrozen" to "isFixed"; and 3) deprecate "isFrozen"

The behavior of "isFixed" and "isFrozen" is to fix the parameter value in the fit, and apply the penalty for the parameter value relative to the prior value.

The behavior of "isPenaltyDisabled" is to fix the parameter value in the fit, and do not apply the penalty for the parameter value relative to the prior value.

Closes #928