### PR TITLE
[Feature] Allow to associate parameter definition with covariance bin index

### DIFF
--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -1156,54 +1156,52 @@ void ParameterSet::defineParameters(){
 
     if( not _parameterDefinitionConfig_.empty() ){
       // Alternative 1: define dials then parameters
-      if (_parameterNamesList_ != nullptr) {
+      ConfigReader selectedParConfig;
+
+      if( _parameterNamesList_ != nullptr ) {
         // Find the parameter using the name from the vector of names for
         // the covariance.
-
-        ConfigReader selectedParConfig;
-
-        // search with name
         std::string parName = _parameterNamesList_->At(par.getParameterIndex())->GetName();
         for( auto& parConfig : _parameterDefinitionConfig_.loop() ){
           parConfig.defineFields({
-            {"name", {"parameterName"}},
+              {"name", {"parameterName"}},
           });
-          if( parConfig.hasField("name") ){
-            if( parName == parConfig.fetchValue<std::string>("name") ){
-              selectedParConfig = parConfig;
-              break;
-            }
+          if( parConfig.hasField("name")
+              and parName == parConfig.fetchValue<std::string>("name") ){
+            selectedParConfig = parConfig;
+            break;
           }
         }
+      }
 
-        // not found? try with the index
-        if( selectedParConfig.empty() ){
-          for( auto& parConfig : _parameterDefinitionConfig_.loop() ){
-            parConfig.defineFields({{"parameterIndex"}});
-            if( parConfig.hasField("parameterIndex") ){
-              if( par.getParameterIndex() == parConfig.fetchValue<int>("parameterIndex") ){
-                selectedParConfig = parConfig;
-                break;
-              }
-            }
+      // Always allow an explicit parameterIndex mapping, even when the
+      // covariance file does not expose a parameter name list.
+      if( selectedParConfig.empty() ){
+        for( auto& parConfig : _parameterDefinitionConfig_.loop() ){
+          parConfig.defineFields({{"parameterIndex"}});
+          if( parConfig.hasField("parameterIndex")
+              and par.getParameterIndex() == parConfig.fetchValue<int>("parameterIndex") ){
+            selectedParConfig = parConfig;
+            break;
           }
         }
-
-        par.setConfig( selectedParConfig );
       }
-      else{
-        // No covariance provided, so find the name based on the order in
-        // the parameter set.
-        auto configVector = _parameterDefinitionConfig_.loop();
-        LogThrowIf(configVector.size() <= par.getParameterIndex(),
-                   "Parameter index out of range");
-        auto& parConfig = configVector.at(par.getParameterIndex());
-        par.setConfig( parConfig );
 
-        LogWarning << "Parameter #" << par.getParameterIndex()
-                   << " not defined by covariance matrix file"
-                   << std::endl;
+      if( selectedParConfig.empty() and par.isEnabled() ){
+        std::stringstream ss;
+        ss << "No parameterDefinitions entry mapped to enabled parameter #"
+           << par.getParameterIndex();
+        if( _parameterNamesList_ != nullptr ){
+          ss << " (\"" << _parameterNamesList_->At(par.getParameterIndex())->GetName() << "\")";
+        }
+        else{
+          ss << ". Please specify \"parameterIndex\" explicitly";
+        }
+        ss << ".";
+        LogWarning << ss.str() << std::endl;
       }
+
+      par.setConfig( selectedParConfig );
     }
     else if( not _dialSetDefinitions_.empty() ){
       // Alternative 2: define dials then parameters

--- a/src/ParametersManager/src/ParameterSet.cpp
+++ b/src/ParametersManager/src/ParameterSet.cpp
@@ -1187,6 +1187,16 @@ void ParameterSet::defineParameters(){
         }
       }
 
+      // If no covariance matrix is defined, parameters are created from the
+      // configuration order itself, so preserving the positional mapping keeps
+      // existing configs working without requiring parameterIndex.
+      if( selectedParConfig.empty() and _priorFullCovarianceMatrix_ == nullptr ){
+        auto configVector = _parameterDefinitionConfig_.loop();
+        if( size_t(par.getParameterIndex()) < configVector.size() ){
+          selectedParConfig = configVector.at(size_t(par.getParameterIndex()));
+        }
+      }
+
       if( selectedParConfig.empty() and par.isEnabled() ){
         std::stringstream ss;
         ss << "No parameterDefinitions entry mapped to enabled parameter #"


### PR DESCRIPTION
This PR will allow user to link parameter definitions with covariance matrix using the index with name is note available.

In practice, this PR allows to write a config this way:
```yaml
name: "Flux"
isEnabled: true
parameterDefinitionFilePath: "./Covariance_Matrix.root"
covarianceMatrix: "postfit_cov"
parametersRange: { min: 0 }

parameterDefinitions:
  - name: "FHC #nu_{#mu} [0; 0.4[ GeV"
    isEnabled: true
    parameterIndex: 0
    dialSetDefinitions:
      - dialType: Normalization
        applyCondition: "[gen_numu_fhc] && [enu_true_GeV] > 0. && [enu_true_GeV] <= 0.4"

  - name: "FHC #nu_{#mu} [0.4; 0.5[ GeV"
    isEnabled: true
    parameterIndex: 1
    dialSetDefinitions:
      - dialType: Normalization
        applyCondition: "[gen_numu_fhc] && [enu_true_GeV] > 0.4 && [enu_true_GeV] <= 0.5"
```

In the current main branch, this wouldn't work as we didn't provide the name of each bin of the covariance matrix. This PR reads `parameterIndex:` and associate with the right covariance bin index.