### PR TITLE
[Python] Adding python handle to convert JsonType to string

### DIFF
--- a/src/PythonInterface/src/PythonInterface.cpp
+++ b/src/PythonInterface/src/PythonInterface.cpp
@@ -103,6 +103,7 @@ PYBIND11_MODULE(GUNDAM, module) {
   // JsonType for the return type
   pybind11::class_<JsonType>(module, "JsonType")
   .def(pybind11::init())
+  .def(pybind11::init([](const std::string& jsonString_){ return JsonType::parse(jsonString_);}), pybind11::arg("jsonString"))
   .def("toString", [](const JsonType& this_, bool shallow_){ return GenericToolbox::Json::toReadableString(this_, shallow_); }, pybind11::arg("shallow") = false)
   ;
 

--- a/src/PythonInterface/src/PythonInterface.cpp
+++ b/src/PythonInterface/src/PythonInterface.cpp
@@ -103,6 +103,7 @@ PYBIND11_MODULE(GUNDAM, module) {
   // JsonType for the return type
   pybind11::class_<JsonType>(module, "JsonType")
   .def(pybind11::init())
+  .def("toString", [](const JsonType& this_, bool shallow_){ return GenericToolbox::Json::toReadableString(this_, shallow_); }, pybind11::arg("shallow") = false)
   ;
 
 

--- a/src/PythonInterface/src/PythonInterface.cpp
+++ b/src/PythonInterface/src/PythonInterface.cpp
@@ -456,7 +456,7 @@ PYBIND11_MODULE(GUNDAM, module) {
   .def("configure", pybind11::overload_cast<const ConfigReader&>(&FitterEngine::configure))
   .def("configure", pybind11::overload_cast<>(&FitterEngine::configure))
   .def("initialize", &FitterEngine::initialize)
-  .def("setRandomSeed", &FitterEngine::setRandomSeed)
+  .def_static("setRandomSeed", &FitterEngine::setRandomSeed)
   .def("fit", &FitterEngine::fit)
   .def("getMinimizer", pybind11::overload_cast<>(&FitterEngine::getMinimizer), pybind11::return_value_policy::reference)
   .def("getLikelihoodInterface", pybind11::overload_cast<>(&FitterEngine::getLikelihoodInterface), pybind11::return_value_policy::reference)

--- a/src/PythonInterface/src/PythonInterface.cpp
+++ b/src/PythonInterface/src/PythonInterface.cpp
@@ -290,6 +290,7 @@ PYBIND11_MODULE(GUNDAM, module) {
   .def("throwParameters", &ParametersManager::throwParameters)
   .def("exportParameterInjectorConfig", &ParametersManager::exportParameterInjectorConfig)
   .def("injectParameterValues", &ParametersManager::injectParameterValues)
+  .def("injectParameterValues", [](ParametersManager& self, const std::string& jsonString){ self.injectParameterValues(JsonType(jsonString)); })
   .def("getParameterSetsList", pybind11::overload_cast<>(&ParametersManager::getParameterSetsList), pybind11::return_value_policy::reference_internal)
   ;
 


### PR DESCRIPTION
Quick PR as it's within the python interface. I'll merge it right after the CI succeed, and bypass the review as usual for the python interface, as it's orthogonal to the main code.