### PR TITLE
[Feature] Friend tree loading alongside main trees

### DIFF
--- a/docs/configuration/DatasetLoader.md
+++ b/docs/configuration/DatasetLoader.md
@@ -82,9 +82,11 @@ filePathList:
         path: "${DATA_DIR}/truth-run1.root:truth"
   - name: "run2"
     path: "${DATA_DIR}/events-run2.root:events"
+    isEnabled: true
     friendList:
       - name: "weights"
         path: "${DATA_DIR}/weights-run2.root:weights"
+        isEnabled: true
       - name: "truth"
         path: "${DATA_DIR}/truth-run2.root:truth"
 
@@ -92,7 +94,7 @@ variableDict:
   - { name: "weight", expr: "weights.nominalWeight" }
 ```
 
-Every named file entry must declare the same friend aliases. Each friend tree must have exactly the same number and order of entries as its corresponding main tree. A branch with a unique name may be referenced without its alias, but `friendAlias.branch` is the recommended form because it remains unambiguous.
+Both main-file and friend entries accept `isEnabled` (default: `true`). Disabled main files are excluded from the chain; disabled friends are not attached. Every enabled file entry must declare the same enabled friend aliases. Each enabled friend tree must have exactly the same number and order of entries as its corresponding main tree. A branch with a unique name may be referenced without its alias, but `friendAlias.branch` is the recommended form because it remains unambiguous.
 
 
 #### data

--- a/docs/configuration/DatasetLoader.md
+++ b/docs/configuration/DatasetLoader.md
@@ -31,7 +31,7 @@ As an entry list
 | tree                    | string                       | Name of the TTree containing the data in each file                          |         |
 | selectionCutFormula     | formula                      | Global selection cut (should return 0 if not selected)                      |         |
 | nominalTreeWeightFormula | formula                     | Formula that returns the base weight of a given event                       |         |
-| filePathList            | list(string)                 | list of ROOT files containing the TTree                                     |         |
+| filePathList            | list(string \| json)          | list of ROOT files containing the TTree; entries can attach friend TTrees   |         |
 | additionalLeavesStorage | list(string)                 | list of variables to be stored in memory                                    |         |
 | variablesTransform      | list(json)                   | Deprecated. Use `variableDict` entries with `evalFromLib` instead.          |         |
 | variableDict            | list(json)                   | dictionary translating a leaf, formula, or shared-library output to a variable name |         |
@@ -61,6 +61,38 @@ variableDict:
         - "TMath::Abs(mode)"
       messageOnError: "optional build hint"
 ```
+
+`filePathList` keeps its historical list-of-strings syntax:
+
+```yaml
+filePathList:
+  - "${DATA_DIR}/events.root"
+```
+
+It can also use named entries to attach ROOT friend trees. The `name` keys identify list entries for configuration overrides; friend names are ROOT aliases and should be used to qualify their branches in formulas.
+
+```yaml
+filePathList:
+  - name: "run1"
+    path: "${DATA_DIR}/events-run1.root:events"
+    friendList:
+      - name: "weights"
+        path: "${DATA_DIR}/weights-run1.root:weights"
+      - name: "truth"
+        path: "${DATA_DIR}/truth-run1.root:truth"
+  - name: "run2"
+    path: "${DATA_DIR}/events-run2.root:events"
+    friendList:
+      - name: "weights"
+        path: "${DATA_DIR}/weights-run2.root:weights"
+      - name: "truth"
+        path: "${DATA_DIR}/truth-run2.root:truth"
+
+variableDict:
+  - { name: "weight", expr: "weights.nominalWeight" }
+```
+
+Every named file entry must declare the same friend aliases. Each friend tree must have exactly the same number and order of entries as its corresponding main tree. A branch with a unique name may be referenced without its alias, but `friendAlias.branch` is the recommended form because it remains unambiguous.
 
 
 #### data

--- a/src/DatasetManager/include/DataDispenserUtils.h
+++ b/src/DatasetManager/include/DataDispenserUtils.h
@@ -36,7 +36,17 @@ struct DataDispenserParameters{
   std::string selectionCutFormulaStr{};
   std::string eventVariableAsWeight{};
   std::vector<std::string> activeLeafNameList{};
-  std::vector<std::string> filePathList{};
+  struct FilePathEntry{
+    struct FriendTree{
+      std::string name{}; // ROOT friend alias
+      std::string path{}; // ROOT file path, optionally followed by :tree/path
+    };
+
+    std::string name{}; // config-list identifier, used by the override mechanism
+    std::string path{}; // ROOT file path, optionally followed by :tree/path
+    std::vector<FriendTree> friendList{};
+  };
+  std::vector<FilePathEntry> filePathList{};
   std::map<std::string, std::string> variableDict{};
   std::map<std::string, EventVarTransformLib> variableDictTransform{};
   std::vector<std::string> additionalVarsStorage{};

--- a/src/DatasetManager/include/DataDispenserUtils.h
+++ b/src/DatasetManager/include/DataDispenserUtils.h
@@ -40,10 +40,12 @@ struct DataDispenserParameters{
     struct FriendTree{
       std::string name{}; // ROOT friend alias
       std::string path{}; // ROOT file path, optionally followed by :tree/path
+      bool isEnabled{true};
     };
 
     std::string name{}; // config-list identifier, used by the override mechanism
     std::string path{}; // ROOT file path, optionally followed by :tree/path
+    bool isEnabled{true};
     std::vector<FriendTree> friendList{};
   };
   std::vector<FilePathEntry> filePathList{};

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -1379,7 +1379,6 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
       if( friendChain == nullptr ){
         friendChain = std::make_shared<TChain>(friendEntry.name.c_str());
         friendChainList->emplace_back(friendChain);
-        LogExitIf(treeChain->AddFriend(friendChain.get(), friendEntry.name.c_str()) == nullptr, "Could not attach friend TChain: " << friendEntry.name);
       }
       friendChain->AddFile(friendSource.filePath.c_str(), nMaxEntries, friendSource.treePath.c_str());
     }
@@ -1392,6 +1391,17 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
         "Friend TChain \"" << friendChain->GetName() << "\" has " << friendChain->GetEntries()
         << " entries while the main TChain has " << treeChain->GetEntries() << ". Friends must be entry-aligned."
     );
+    LogExitIf(
+        treeChain->AddFriend(friendChain.get(), friendChain->GetName()) == nullptr,
+        "Could not attach friend TChain: " << friendChain->GetName()
+    );
+  }
+
+  // ROOT 6.24 connects the current trees of friend TChains lazily. Load the
+  // first entry now so qualified friend expressions are available when a
+  // TreeBuffer/TTreeFormula is initialized immediately after openChain().
+  if( not friendChainList->empty() and treeChain->GetEntries() > 0 ){
+    LogExitIf(treeChain->LoadTree(0) < 0, "Could not load the first entry of the main TChain with its friends.");
   }
 
   return treeChain;

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -37,6 +37,40 @@
 
 namespace {
 
+  struct RootFileAndTreePath{
+    std::string filePath{};
+    std::string treePath{};
+  };
+
+  RootFileAndTreePath resolveRootFileAndTreePath(
+      const std::string& configuredPath_,
+      const std::string& defaultTreePath_
+  ){
+    RootFileAndTreePath out;
+    out.filePath = GenericToolbox::expandEnvironmentVariables(configuredPath_);
+    GenericToolbox::replaceSubstringInsideInputString(out.filePath, "//", "/");
+
+    out.treePath = defaultTreePath_;
+    auto chunks = GenericToolbox::splitString(out.filePath, ":", true);
+    if( chunks.size() > 1 ){
+      out.treePath = chunks[1];
+      out.filePath = chunks[0];
+    }
+
+    LogExitIf(out.treePath.empty(), "TTree path not set for ROOT file: " << configuredPath_);
+    return out;
+  }
+
+  void validateRootFileAndTreePath(
+      const RootFileAndTreePath& source_,
+      const std::string& sourceDescription_
+  ){
+    LogExitIf(
+        not GenericToolbox::doesTFileIsValid(source_.filePath, {source_.treePath}),
+        "Could not open " << sourceDescription_ << ": " << source_.filePath << " with TTree " << source_.treePath
+    );
+  }
+
   bool hasFormulaReferences(const std::string& formula_){
     return not FormulaUtils::extractFormulaReferenceNames(formula_).empty();
   }
@@ -601,7 +635,63 @@ void DataDispenser::configureImpl(){
 
   // options
   _config_.fillValue(_parameters_.globalTreePath, "tree");
-  _config_.fillValue(_parameters_.filePathList, "filePathList");
+  _parameters_.filePathList.clear();
+  if( const auto* filePathListConfig = _config_.getConfigEntry("filePathList").second; filePathListConfig != nullptr ){
+    LogExitIf(not filePathListConfig->is_array(), "filePathList must be a list.");
+    _parameters_.filePathList.reserve(filePathListConfig->size());
+
+    std::set<std::string> expectedFriendNameSet;
+    bool isFirstEntry{true};
+    for( size_t iEntry = 0; iEntry < filePathListConfig->size(); ++iEntry ){
+      const auto& filePathConfig = filePathListConfig->at(iEntry);
+      auto& filePathEntry = _parameters_.filePathList.emplace_back();
+
+      // Keep the legacy list(string) syntax fully compatible.
+      if( filePathConfig.is_string() ){
+        filePathEntry.path = GenericToolbox::Json::get<std::string>(filePathConfig);
+      }
+      else{
+        LogExitIf(not filePathConfig.is_object(), "filePathList/" << iEntry << " must be a string or an object.");
+        ConfigReader entryConfig(filePathConfig);
+        entryConfig.setParentPath(GenericToolbox::joinPath(_config_.getParentPath(), "filePathList", iEntry));
+        entryConfig.defineFields({
+          {FieldFlag::MANDATORY, "name"},
+          {FieldFlag::MANDATORY, "path"},
+          {"friendList"},
+        });
+        entryConfig.checkConfiguration();
+        filePathEntry.name = entryConfig.fetchValue<std::string>("name");
+        filePathEntry.path = entryConfig.fetchValue<std::string>("path");
+
+        for( auto& friendConfig : entryConfig.loop("friendList") ){
+          friendConfig.defineFields({
+            {FieldFlag::MANDATORY, "name"},
+            {FieldFlag::MANDATORY, "path"},
+          });
+          friendConfig.checkConfiguration();
+
+          auto& friendEntry = filePathEntry.friendList.emplace_back();
+          friendEntry.name = friendConfig.fetchValue<std::string>("name");
+          friendEntry.path = friendConfig.fetchValue<std::string>("path");
+        }
+      }
+      std::set<std::string> friendNameSet;
+      for( const auto& friendEntry : filePathEntry.friendList ){
+        LogExitIf(
+            not friendNameSet.emplace(friendEntry.name).second,
+            "Duplicate friend name \"" << friendEntry.name << "\" in filePathList/" << iEntry
+        );
+      }
+      if( isFirstEntry ){ expectedFriendNameSet = std::move(friendNameSet); }
+      else{
+        LogExitIf(
+            friendNameSet != expectedFriendNameSet,
+            "Every filePathList entry must define the same friend names, so that the friend TChains remain aligned."
+        );
+      }
+      isFirstEntry = false;
+    }
+  }
   _config_.fillValue(_parameters_.additionalVarsStorage, "additionalLeavesStorage");
   _config_.fillValue(_parameters_.dummyVariablesList, "dummyVariablesList");
   _config_.fillValue(_parameters_.useReweightEngine, "useReweightEngine");
@@ -659,9 +749,17 @@ void DataDispenser::load(Propagator& propagator_){
     return;
   }
 
-  for( const auto& file: _parameters_.filePathList){
-    std::string path = GenericToolbox::expandEnvironmentVariables(file);
-    LogExitIf(not GenericToolbox::doesTFileIsValid(path, {_parameters_.globalTreePath}), "Invalid file: " << path);
+  for( const auto& fileEntry : _parameters_.filePathList ){
+    validateRootFileAndTreePath(
+        resolveRootFileAndTreePath(fileEntry.path, _parameters_.globalTreePath),
+        "ROOT file"
+    );
+    for( const auto& friendEntry : fileEntry.friendList ){
+      validateRootFileAndTreePath(
+          resolveRootFileAndTreePath(friendEntry.path, _parameters_.globalTreePath),
+          "friend \"" + friendEntry.name + "\""
+      );
+    }
   }
 
   this->parseStringParameters();
@@ -1220,41 +1318,77 @@ const std::string& DataDispenser::getVariableExpression(const std::string& varia
 std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
   LogInfoIf(verbose_) << "Opening ROOT files containing events..." << std::endl;
 
-  std::shared_ptr<TChain> treeChain(std::make_shared<TChain>());
-  for( const auto& file: _parameters_.filePathList){
-    std::string name = GenericToolbox::expandEnvironmentVariables(file);
-    GenericToolbox::replaceSubstringInsideInputString(name, "//", "/");
+  // TFriendElement does not own a TChain supplied through AddFriend(TTree*, ...).
+  // Keep the friend chains alive through the lifetime of their master chain.
+  auto friendChainList = std::make_shared<std::vector<std::shared_ptr<TChain>>>();
+  std::shared_ptr<TChain> treeChain(new TChain(), [friendChainList](TChain* chain){ delete chain; });
+
+  for( const auto& fileEntry : _parameters_.filePathList ){
+    auto source = resolveRootFileAndTreePath(fileEntry.path, _parameters_.globalTreePath);
 
     if( verbose_ ){
       LogScopeIndent;
-      LogInfo << name << std::endl;
+      LogInfo << source.filePath << ":" << source.treePath << std::endl;
     }
 
-    std::string treePath{_parameters_.globalTreePath};
-    auto chunks = GenericToolbox::splitString(name, ":", true);
-    if( chunks.size() > 1 ){ treePath = chunks[1]; name = chunks[0];  }
+    validateRootFileAndTreePath(source, "ROOT file");
 
-    LogExitIf( treePath.empty(), "TTree path not set." );
+    Long64_t sourceNbEntries{-1};
+    std::unique_ptr<TFile> temp{};
+    if( _parameters_.fractionOfEntries != 1. or not fileEntry.friendList.empty() ){
+      temp.reset(TFile::Open(source.filePath.c_str()));
+      LogExitIf(temp == nullptr, "Error while opening TFile: " << source.filePath);
 
-    LogExitIf( not GenericToolbox::doesTFileIsValid(name, {treePath}), "Could not open TFile: " << name << " with TTree " << treePath);
+      auto* tree = temp->Get<TTree>(source.treePath.c_str());
+      LogExitIf(tree == nullptr, "Error while opening TTree: " << source.treePath << " in " << source.filePath);
+      sourceNbEntries = tree->GetEntries();
+    }
 
     Long64_t nMaxEntries{TTree::kMaxEntries};
     if( _parameters_.fractionOfEntries != 1. ){
-      std::unique_ptr<TFile> temp{TFile::Open(name.c_str())};
-      LogExitIf(temp== nullptr, "Error while opening TFile: " << name);
-
-      auto* tree = temp->Get<TTree>(treePath.c_str());
-      LogExitIf(tree== nullptr, "Error while opening TTree: " << treePath << " in " << name);
-
-      nMaxEntries = Long64_t( double(tree->GetEntries()) * _parameters_.fractionOfEntries );
+      nMaxEntries = Long64_t( double(sourceNbEntries) * _parameters_.fractionOfEntries );
       if( verbose_ ){
         LogScopeIndent;
         LogWarning << "Max entries: " << nMaxEntries << std::endl;
       }
 
     }
-    treeChain->AddFile(name.c_str(), nMaxEntries, treePath.c_str());
+    treeChain->AddFile(source.filePath.c_str(), nMaxEntries, source.treePath.c_str());
 
+    for( const auto& friendEntry : fileEntry.friendList ){
+      auto friendSource = resolveRootFileAndTreePath(friendEntry.path, _parameters_.globalTreePath);
+      validateRootFileAndTreePath(friendSource, "friend \"" + friendEntry.name + "\"");
+
+      std::unique_ptr<TFile> friendFile{TFile::Open(friendSource.filePath.c_str())};
+      LogExitIf(friendFile == nullptr, "Error while opening friend file: " << friendSource.filePath);
+      auto* friendTree = friendFile->Get<TTree>(friendSource.treePath.c_str());
+      LogExitIf(friendTree == nullptr, "Error while opening friend TTree: " << friendSource.treePath << " in " << friendSource.filePath);
+      LogExitIf(
+          friendTree->GetEntries() != sourceNbEntries,
+          "Friend \"" << friendEntry.name << "\" in " << friendSource.filePath << " has " << friendTree->GetEntries()
+          << " entries, while its main tree in " << source.filePath << " has " << sourceNbEntries << ". Friends must be entry-aligned."
+      );
+
+      std::shared_ptr<TChain> friendChain;
+      for( const auto& existingFriendChain : *friendChainList ){
+        if( existingFriendChain->GetName() == friendEntry.name ){ friendChain = existingFriendChain; break; }
+      }
+      if( friendChain == nullptr ){
+        friendChain = std::make_shared<TChain>(friendEntry.name.c_str());
+        friendChainList->emplace_back(friendChain);
+        LogExitIf(treeChain->AddFriend(friendChain.get(), friendEntry.name.c_str()) == nullptr, "Could not attach friend TChain: " << friendEntry.name);
+      }
+      friendChain->AddFile(friendSource.filePath.c_str(), nMaxEntries, friendSource.treePath.c_str());
+    }
+
+  }
+
+  for( const auto& friendChain : *friendChainList ){
+    LogExitIf(
+        friendChain->GetEntries() != treeChain->GetEntries(),
+        "Friend TChain \"" << friendChain->GetName() << "\" has " << friendChain->GetEntries()
+        << " entries while the main TChain has " << treeChain->GetEntries() << ". Friends must be entry-aligned."
+    );
   }
 
   return treeChain;

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -642,7 +642,7 @@ void DataDispenser::configureImpl(){
     _parameters_.filePathList.reserve(filePathListConfig->size());
 
     std::set<std::string> expectedFriendNameSet;
-    bool isFirstEntry{true};
+    bool hasEnabledFilePathEntry{false};
     for( size_t iEntry = 0; iEntry < filePathListConfig->size(); ++iEntry ){
       const auto& filePathConfig = filePathListConfig->at(iEntry);
       _parameters_.filePathList.emplace_back();
@@ -659,16 +659,19 @@ void DataDispenser::configureImpl(){
         entryConfig.defineFields({
           {FieldFlag::MANDATORY, "name"},
           {FieldFlag::MANDATORY, "path"},
+          {"isEnabled"},
           {"friendList"},
         });
         entryConfig.checkConfiguration();
         filePathEntry.name = entryConfig.fetchValue<std::string>("name");
         filePathEntry.path = entryConfig.fetchValue<std::string>("path");
+        entryConfig.fillValue(filePathEntry.isEnabled, "isEnabled");
 
         for( auto& friendConfig : entryConfig.loop("friendList") ){
           friendConfig.defineFields({
             {FieldFlag::MANDATORY, "name"},
             {FieldFlag::MANDATORY, "path"},
+            {"isEnabled"},
           });
           friendConfig.checkConfiguration();
 
@@ -676,6 +679,7 @@ void DataDispenser::configureImpl(){
           auto& friendEntry = filePathEntry.friendList.back();
           friendEntry.name = friendConfig.fetchValue<std::string>("name");
           friendEntry.path = friendConfig.fetchValue<std::string>("path");
+          friendConfig.fillValue(friendEntry.isEnabled, "isEnabled");
         }
       }
       std::set<std::string> friendNameSet;
@@ -685,14 +689,22 @@ void DataDispenser::configureImpl(){
             "Duplicate friend name \"" << friendEntry.name << "\" in filePathList/" << iEntry
         );
       }
-      if( isFirstEntry ){ expectedFriendNameSet = std::move(friendNameSet); }
+      if( not filePathEntry.isEnabled ){ continue; }
+
+      std::set<std::string> enabledFriendNameSet;
+      for( const auto& friendEntry : filePathEntry.friendList ){
+        if( friendEntry.isEnabled ){ enabledFriendNameSet.emplace(friendEntry.name); }
+      }
+      if( not hasEnabledFilePathEntry ){
+        expectedFriendNameSet = std::move(enabledFriendNameSet);
+        hasEnabledFilePathEntry = true;
+      }
       else{
         LogExitIf(
-            friendNameSet != expectedFriendNameSet,
-            "Every filePathList entry must define the same friend names, so that the friend TChains remain aligned."
+            enabledFriendNameSet != expectedFriendNameSet,
+            "Every enabled filePathList entry must define the same enabled friend names, so that the friend TChains remain aligned."
         );
       }
-      isFirstEntry = false;
     }
   }
   _config_.fillValue(_parameters_.additionalVarsStorage, "additionalLeavesStorage");
@@ -753,11 +765,13 @@ void DataDispenser::load(Propagator& propagator_){
   }
 
   for( const auto& fileEntry : _parameters_.filePathList ){
+    if( not fileEntry.isEnabled ){ continue; }
     validateRootFileAndTreePath(
         resolveRootFileAndTreePath(fileEntry.path, _parameters_.globalTreePath),
         "ROOT file"
     );
     for( const auto& friendEntry : fileEntry.friendList ){
+      if( not friendEntry.isEnabled ){ continue; }
       validateRootFileAndTreePath(
           resolveRootFileAndTreePath(friendEntry.path, _parameters_.globalTreePath),
           "friend \"" + friendEntry.name + "\""
@@ -1327,6 +1341,7 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
   std::shared_ptr<TChain> treeChain(new TChain(), [friendChainList](TChain* chain){ delete chain; });
 
   for( const auto& fileEntry : _parameters_.filePathList ){
+    if( not fileEntry.isEnabled ){ continue; }
     auto source = resolveRootFileAndTreePath(fileEntry.path, _parameters_.globalTreePath);
 
     if( verbose_ ){
@@ -1338,7 +1353,11 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
 
     Long64_t sourceNbEntries{-1};
     std::unique_ptr<TFile> temp{};
-    if( _parameters_.fractionOfEntries != 1. or not fileEntry.friendList.empty() ){
+    bool hasEnabledFriend{false};
+    for( const auto& friendEntry : fileEntry.friendList ){
+      if( friendEntry.isEnabled ){ hasEnabledFriend = true; break; }
+    }
+    if( _parameters_.fractionOfEntries != 1. or hasEnabledFriend ){
       temp.reset(TFile::Open(source.filePath.c_str()));
       LogExitIf(temp == nullptr, "Error while opening TFile: " << source.filePath);
 
@@ -1359,6 +1378,7 @@ std::shared_ptr<TChain> DataDispenser::openChain(bool verbose_) const{
     treeChain->AddFile(source.filePath.c_str(), nMaxEntries, source.treePath.c_str());
 
     for( const auto& friendEntry : fileEntry.friendList ){
+      if( not friendEntry.isEnabled ){ continue; }
       auto friendSource = resolveRootFileAndTreePath(friendEntry.path, _parameters_.globalTreePath);
       validateRootFileAndTreePath(friendSource, "friend \"" + friendEntry.name + "\"");
 

--- a/src/DatasetManager/src/DataDispenser.cpp
+++ b/src/DatasetManager/src/DataDispenser.cpp
@@ -636,7 +636,8 @@ void DataDispenser::configureImpl(){
   // options
   _config_.fillValue(_parameters_.globalTreePath, "tree");
   _parameters_.filePathList.clear();
-  if( const auto* filePathListConfig = _config_.getConfigEntry("filePathList").second; filePathListConfig != nullptr ){
+  const auto* filePathListConfig = _config_.getConfigEntry("filePathList").second;
+  if( filePathListConfig != nullptr ){
     LogExitIf(not filePathListConfig->is_array(), "filePathList must be a list.");
     _parameters_.filePathList.reserve(filePathListConfig->size());
 
@@ -644,7 +645,8 @@ void DataDispenser::configureImpl(){
     bool isFirstEntry{true};
     for( size_t iEntry = 0; iEntry < filePathListConfig->size(); ++iEntry ){
       const auto& filePathConfig = filePathListConfig->at(iEntry);
-      auto& filePathEntry = _parameters_.filePathList.emplace_back();
+      _parameters_.filePathList.emplace_back();
+      auto& filePathEntry = _parameters_.filePathList.back();
 
       // Keep the legacy list(string) syntax fully compatible.
       if( filePathConfig.is_string() ){
@@ -670,7 +672,8 @@ void DataDispenser::configureImpl(){
           });
           friendConfig.checkConfiguration();
 
-          auto& friendEntry = filePathEntry.friendList.emplace_back();
+          filePathEntry.friendList.emplace_back();
+          auto& friendEntry = filePathEntry.friendList.back();
           friendEntry.name = friendConfig.fetchValue<std::string>("name");
           friendEntry.path = friendConfig.fetchValue<std::string>("path");
         }

--- a/src/DatasetManager/src/DataDispenserUtils.cpp
+++ b/src/DatasetManager/src/DataDispenserUtils.cpp
@@ -18,7 +18,7 @@ std::string DataDispenserParameters::getSummary() const{
   ss << std::endl << GET_VAR_NAME_VALUE(nominalWeightFormulaStr);
   ss << std::endl << GET_VAR_NAME_VALUE(selectionCutFormulaStr);
   ss << std::endl << "activeLeafNameList = " << GenericToolbox::toString(activeLeafNameList, true);
-  ss << std::endl << "filePathList = " << GenericToolbox::toString(filePathList, true);
+  ss << std::endl << "filePathList = " << GenericToolbox::toString(filePathList, [](const DataDispenserParameters::FilePathEntry& entry){ return entry.path; }, true);
   ss << std::endl << "variableDict = " << GenericToolbox::toString(variableDict, true);
   ss << std::endl << "additionalVarsStorage = " << GenericToolbox::toString(additionalVarsStorage, true);
   return ss.str();

--- a/src/Utils/src/FormulaUtils.cpp
+++ b/src/Utils/src/FormulaUtils.cpp
@@ -39,6 +39,22 @@ namespace {
     return std::isalpha(static_cast<unsigned char>(c_)) or c_ == '_';
   }
 
+  // ROOT qualifies friend-tree leaves with an alias, e.g. friend.branch.
+  // Treat the complete qualified path as one leaf expression rather than as
+  // two independent bare variables.
+  size_t consumeQualifiedIdentifier(const std::string& formula_, size_t cursor_){
+    while( cursor_ < formula_.size() and isIdentifierChar(formula_[cursor_]) ){ cursor_++; }
+    while(
+        cursor_ + 1 < formula_.size()
+        and formula_[cursor_] == '.'
+        and isIdentifierStart(formula_[cursor_ + 1])
+    ){
+      cursor_ += 2;
+      while( cursor_ < formula_.size() and isIdentifierChar(formula_[cursor_]) ){ cursor_++; }
+    }
+    return cursor_;
+  }
+
   bool isBareIdentifierFormulaToken(
       const std::string& formula_,
       size_t begin_,
@@ -224,8 +240,7 @@ std::vector<std::string> extractBareVariableNames(const std::string& formula_){
     }
 
     auto begin = cursor;
-    cursor++;
-    while( cursor < formula_.size() and isIdentifierChar(formula_[cursor]) ){ cursor++; }
+    cursor = consumeQualifiedIdentifier(formula_, cursor + 1);
 
     if( isBareIdentifierFormulaToken(formula_, begin, cursor) ){
       addUnique(output, formula_.substr(begin, cursor - begin));
@@ -265,8 +280,7 @@ std::string convertBareVariablesToFormulaParameters(const std::string& formula_)
     }
 
     auto begin = cursor;
-    cursor++;
-    while( cursor < formula_.size() and isIdentifierChar(formula_[cursor]) ){ cursor++; }
+    cursor = consumeQualifiedIdentifier(formula_, cursor + 1);
 
     if( isBareIdentifierFormulaToken(formula_, begin, cursor) ){
       output += "[";

--- a/tests/fast-tests/214FriendTrees.py
+++ b/tests/fast-tests/214FriendTrees.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import sys
+from array import array
+from pathlib import Path
+
+
+def write_root_files(main_path: Path, friend_path: Path) -> None:
+    import uproot
+
+    with uproot.recreate(main_path) as root_file:
+        tree = root_file.mktree("events", {"event": "int32"})
+        tree.extend({"event": array("i", [0, 1, 2, 3])})
+
+    with uproot.recreate(friend_path) as root_file:
+        tree = root_file.mktree("friend_events", {"friendValue": "float64"})
+        tree.extend({"friendValue": array("d", [0.25, 0.75, 1.25, 1.75])})
+
+
+def build_config(main_path: Path, friend_path: Path) -> str:
+    return f"""
+fitterEngineConfig:
+  likelihoodInterfaceConfig:
+    jointProbabilityConfig:
+      type: PoissonLLH
+    dataSetList:
+      - name: FriendTreeSample
+        isEnabled: true
+        model:
+          filePathList:
+            - name: main
+              path: "{main_path}:events"
+              friendList:
+                - name: friend
+                  path: "{friend_path}:friend_events"
+          variableDict:
+            - name: X
+              expr: "friend.friendValue"
+  propagatorConfig:
+    sampleSetConfig:
+      sampleList:
+        - name: X
+          isEnabled: true
+          binning: {{ binningDefinition: [{{ name: X, edges: [0, 1, 2] }}] }}
+          dataSets: [FriendTreeSample]
+"""
+
+
+def main() -> int:
+    import GUNDAM
+
+    work_dir = Path.cwd()
+    main_path = work_dir / "214FriendTrees-main.root"
+    friend_path = work_dir / "214FriendTrees-friend.root"
+    write_root_files(main_path, friend_path)
+
+    GUNDAM.setRuntimeWorkingDirectory(str(work_dir))
+    GUNDAM.setLightOutputMode(True)
+    GUNDAM.setNumberOfThreads(1)
+
+    config_builder = GUNDAM.ConfigUtils.ConfigBuilder()
+    config_builder.setConfigFromYamlString(build_config(main_path, friend_path))
+    config = GUNDAM.ConfigUtils.ConfigReader(config_builder.getConfig())
+    config.defineField(GUNDAM.ConfigUtils.ConfigReader.FieldDefinition("fitterEngineConfig"))
+
+    engine = GUNDAM.FitterEngine()
+    engine.setConfig(config.fetchValueConfigReader("fitterEngineConfig"))
+    engine.configure()
+    likelihood = engine.getLikelihoodInterface()
+    likelihood.initialize()
+    likelihood.propagateAndEvalLikelihood()
+
+    sample = likelihood.getModelPropagator().getSampleSet().getSampleList()[0]
+    contents = [bin_content.sumWeights for bin_content in sample.getHistogram().getBinContentList()]
+    if contents != [2.0, 2.0]:
+        print(f"FAIL: expected [2.0, 2.0] from friend.friendValue, got {contents}")
+        return 1
+
+    print("SUCCESS: friend-tree branch is available through its configured alias.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`filePathList` now supports named entries with ROOT friend trees. Each friend is assigned an alias, which can be used in ROOT formulas as `alias.branch`. Friend trees must be entry-by-entry aligned with their corresponding main tree.

Example of configuration syntax:
```yaml
dataSetList:
  - name: FriendTreeSample
    isEnabled: true
    model:
      filePathList:
        - name: main
          path: "${DATA_DIR}/file.root:mainTree"
          friendList:
            - name: friend
              path: "${DATA_DIR}/friendFile.root:friendTree"
      variableDict:
        - name: X
          expr: "friendTree.friendValue"
```

Keeping compatibility with `filePathList` taking a list of string.